### PR TITLE
Add last-error reporting to FFI (iOS + Android)

### DIFF
--- a/android/src/main/java/com/shoesproxy/ShoesNative.kt
+++ b/android/src/main/java/com/shoesproxy/ShoesNative.kt
@@ -114,4 +114,12 @@ object ShoesNative {
      * @return true if the service is active.
      */
     external fun isRunning(): Boolean
+
+    /**
+     * Get the last error message from the shoes service.
+     *
+     * Returns the error string if the service stopped due to an error,
+     * or null if no error has occurred (normal shutdown or still running).
+     */
+    external fun getLastError(): String?
 }

--- a/include/shoes.h
+++ b/include/shoes.h
@@ -90,4 +90,23 @@ const char *shoes_get_version(void);
  */
 int shoes_set_log_file(const char *path);
 
+/**
+ * Get the last error message from the shoes service.
+ *
+ * Returns a heap-allocated null-terminated string containing the error,
+ * or NULL if no error has occurred. The caller must free the returned
+ * string using `shoes_free_string()`.
+ *
+ * Thread-safe. The returned string is a copy.
+ */
+char *shoes_get_last_error(void);
+
+/**
+ * Free a string returned by `shoes_get_last_error()`.
+ *
+ * # Safety
+ * `ptr` must be a pointer returned by `shoes_get_last_error()`, or NULL.
+ */
+void shoes_free_string(char *ptr);
+
 #endif  /* SHOES_H */

--- a/src/ffi/android.rs
+++ b/src/ffi/android.rs
@@ -245,12 +245,18 @@ pub extern "system" fn Java_com_shoesproxy_ShoesNative_start<'local>(
     let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let running_clone = running.clone();
 
+    common::clear_last_error();
+
     runtime.spawn(async move {
         info!("Shoes service task started");
 
         match common::start_from_config(&config_str, shutdown_rx).await {
             Ok(()) => info!("Shoes service stopped normally"),
-            Err(e) => error!("Shoes service error: {}", e),
+            Err(e) => {
+                let msg = e.to_string();
+                error!("Shoes service error: {}", msg);
+                common::set_last_error(msg);
+            }
         }
 
         running_clone.store(false, Ordering::SeqCst);
@@ -298,5 +304,23 @@ pub extern "system" fn Java_com_shoesproxy_ShoesNative_isRunning(
         JNI_TRUE
     } else {
         JNI_FALSE
+    }
+}
+
+/// Get the last error message from the shoes service.
+///
+/// # Returns
+/// * Error message string, or null if no error has occurred.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_shoesproxy_ShoesNative_getLastError<'local>(
+    mut unowned: EnvUnowned<'local>,
+    _class: JClass<'local>,
+) -> JString<'local> {
+    match common::get_last_error() {
+        Some(msg) => match unowned.with_env(|env| env.new_string(&msg)).into_outcome() {
+            Outcome::Ok(s) => s,
+            _ => JString::null(),
+        },
+        None => JString::null(),
     }
 }

--- a/src/ffi/common.rs
+++ b/src/ffi/common.rs
@@ -29,6 +29,10 @@ pub static TUN_SERVICE: OnceLock<parking_lot::Mutex<Option<TunServiceHandle>>> =
 /// Global flag to track initialization.
 pub static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
+/// Last error message from the service. Set when `start_from_config` fails
+/// or the service stops with an error. Read via `shoes_get_last_error()`.
+pub static LAST_ERROR: OnceLock<parking_lot::Mutex<Option<String>>> = OnceLock::new();
+
 /// Handle to a running TUN service.
 pub struct TunServiceHandle {
     /// Tokio runtime running the service.
@@ -107,6 +111,24 @@ pub fn stop_service() {
     }
 
     info!("TUN service stop completed");
+}
+
+/// Store an error message.
+pub fn set_last_error(error: String) {
+    let err = LAST_ERROR.get_or_init(|| parking_lot::Mutex::new(None));
+    *err.lock() = Some(error);
+}
+
+/// Clear the last error message (called on successful start).
+pub fn clear_last_error() {
+    if let Some(err) = LAST_ERROR.get() {
+        *err.lock() = None;
+    }
+}
+
+/// Get the last error message, if any.
+pub fn get_last_error() -> Option<String> {
+    LAST_ERROR.get().and_then(|m| m.lock().clone())
 }
 
 /// Check if the TUN service is running.
@@ -209,4 +231,45 @@ pub async fn start_from_config(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serialize tests that mutate shared LAST_ERROR state.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_set_and_get_last_error() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_last_error();
+
+        assert!(get_last_error().is_none());
+
+        set_last_error("connection refused".to_string());
+        assert_eq!(get_last_error().as_deref(), Some("connection refused"));
+    }
+
+    #[test]
+    fn test_clear_last_error() {
+        let _guard = TEST_LOCK.lock().unwrap();
+
+        set_last_error("some error".to_string());
+        assert!(get_last_error().is_some());
+
+        clear_last_error();
+        assert!(get_last_error().is_none());
+    }
+
+    #[test]
+    fn test_set_overwrites_previous_error() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_last_error();
+
+        set_last_error("first error".to_string());
+        set_last_error("second error".to_string());
+        assert_eq!(get_last_error().as_deref(), Some("second error"));
+    }
 }

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -19,7 +19,7 @@
 //! shoes_stop(handle)
 //! ```
 
-use std::ffi::{CStr, c_char, c_int, c_long};
+use std::ffi::{CStr, CString, c_char, c_int, c_long};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -166,10 +166,16 @@ pub unsafe extern "C" fn shoes_start(
     let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let running_clone = running.clone();
 
+    common::clear_last_error();
+
     runtime.spawn(async move {
         match common::start_from_config(&config_str, shutdown_rx).await {
             Ok(()) => info!("shoes service stopped normally"),
-            Err(e) => error!("shoes service error: {}", e),
+            Err(e) => {
+                let msg = e.to_string();
+                error!("shoes service error: {}", msg);
+                common::set_last_error(msg);
+            }
         }
         running_clone.store(false, Ordering::SeqCst);
     });
@@ -242,4 +248,34 @@ pub unsafe extern "C" fn shoes_set_log_file(path: *const c_char) -> c_int {
     };
 
     setup_log_file(path_str)
+}
+
+/// Get the last error message from the shoes service.
+///
+/// Returns a null-terminated C string containing the error message,
+/// or NULL if no error has occurred. The caller must free the returned
+/// string using `shoes_free_string()`.
+///
+/// Thread-safe. The returned string is a copy — safe to use after
+/// subsequent shoes API calls.
+#[unsafe(no_mangle)]
+pub extern "C" fn shoes_get_last_error() -> *mut c_char {
+    match common::get_last_error() {
+        Some(msg) => match CString::new(msg) {
+            Ok(cstr) => cstr.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Free a string returned by `shoes_get_last_error()`.
+///
+/// # Safety
+/// `ptr` must be a pointer returned by `shoes_get_last_error()`, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn shoes_free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(CString::from_raw(ptr));
+    }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -39,7 +39,7 @@
 //! - `shoes_stop` signals shutdown and waits for cleanup
 
 // Common utilities shared between iOS and Android
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(any(target_os = "android", target_os = "ios", test))]
 mod common;
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
## Problem

`shoes_start` returns immediately but errors happen asynchronously (config parsing failures, tunnel setup errors, runtime crashes). There was no way for the host app to retrieve the error message after the fact.

## Solution

Add a `LAST_ERROR` global (`OnceLock<parking_lot::Mutex<Option<String>>>`) in `ffi/common.rs` shared by both platforms.

**Lifecycle:** clear on start → set on async failure → read by app.

### iOS

- `shoes_get_last_error()` returns a heap-allocated C string via `CString::into_raw()`, or `NULL` if no error
- Caller **must** free with `shoes_free_string(ptr)` — the Swift wrapper always pairs these calls
- `shoes_free_string()` added for safe deallocation

### Android

- `ShoesNative.getLastError()` returns `String?` via JNI
- Returns `JString::null()` if no error stored

## Files changed

| File | Change |
|------|--------|
| `src/ffi/common.rs` | `LAST_ERROR` global + `set/clear/get_last_error()` + tests |
| `src/ffi/ios.rs` | `shoes_get_last_error()` + `shoes_free_string()` exports |
| `src/ffi/android.rs` | `ShoesNative.getLastError()` JNI implementation |
| `src/ffi/mod.rs` | Include `common` module in test builds |
| `include/shoes.h` | C header with `shoes_get_last_error` + `shoes_free_string` |
| `ShoesNative.kt` | Kotlin `getLastError()` external declaration |

## Test plan

- [x] `cargo test --lib --features ffi ffi::common` — 3 unit tests pass (set/get, clear, overwrite)
- [ ] iOS: call `shoes_get_last_error()` after a failed start, verify error string, free with `shoes_free_string()`
- [ ] Android: call `ShoesNative.getLastError()` after a failed start, verify non-null error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)