### PR TITLE
Migrate Android library to AGP 9.0 with version catalog

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.6'
+          gradle-version: '9.5.0'
 
       - name: Set NDK path
         run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("com.android.library") version "8.3.2"
-    id("org.jetbrains.kotlin.android") version "1.9.22"
+    alias(libs.plugins.android.library)
+    // kotlin-android removed: AGP 9.0 has built-in Kotlin support
 }
 
 android {
     namespace = "com.shoesproxy"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21
@@ -21,10 +21,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     sourceSets {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,3 @@
 android.useAndroidX=true
-android.enableJetifier=false
-kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+agp = "9.0.1"
+
+[plugins]
+android-library = { id = "com.android.library", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Modernize the Android library build: upgrade to AGP 9.0 and add a Gradle version catalog so plugin versions are no longer hardcoded in `build.gradle.kts`.

## Changes

| What | Before | After |
|------|--------|-------|
| AGP | 8.3.2 (hardcoded) | 9.0.1 (via `libs.versions.toml`) |
| Kotlin plugin | `kotlin-android` 1.9.22 | Removed — AGP 9.0 built-in Kotlin |
| `kotlinOptions` | `jvmTarget = "17"` | Removed — inherited from `compileOptions.targetCompatibility` |
| `compileSdk` | 34 | 35 (AGP 9.0 requirement) |
| CI Gradle | 8.6 | 9.5.0 |
| Plugin versions | Hardcoded in `build.gradle.kts` | `gradle/libs.versions.toml` catalog |

## Removed from `gradle.properties`

- `android.enableJetifier=false` — Jetifier was removed in AGP 9.0
- `kotlin.code.style=official` — no longer relevant with built-in Kotlin

## Verification

- `assembleRelease` builds successfully with Gradle 9.4 + AGP 9.0.1

## Test plan

- [x] CI: `Build Android AAR` job passes
- [ ] Consuming projects can override AGP/Kotlin versions via their own version catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)