### PR TITLE
fix(android): disable jemalloc for Android targets to fix NDK cross-compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ serde_json = "*"
 tempfile = "*"
 tokio-rustls = "*"
 
-# jemalloc for better memory performance (not supported on Windows MSVC or iOS)
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios")))'.dependencies]
+# jemalloc for better memory performance (not supported on Windows MSVC, iOS, or Android)
+[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
 tikv-jemallocator = "*"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,10 @@ mod vmess;
 mod websocket;
 mod xudp;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios")))]
+#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios")))]
+#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
### What does this PR do?
This PR disables the `tikv-jemallocator` dependency for Android targets (`target_os = "android"`) in both `Cargo.toml` and `src/main.rs`.

### Why is this needed?
When compiling the Android native library (`libshoes.so`) using `cargo-ndk`, the cross-compilation of `tikv-jemalloc-sys` currently fails with `exit code: 101` on non-Linux host machines (like Windows). The build script of `jemalloc-sys` severely struggles with the NDK environment.

Since Android clients usually handle individual proxy connections rather than high-throughput server loads—and modern Android handles memory allocation efficiently (e.g., using [Scudo](https://source.android.com/docs/security/test/scudo))—building `jemalloc` for Android is unnecessary and breaks the `build-android.sh` workflow.
