### PR TITLE
Tproxy inbound support (linux only)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -293,6 +293,27 @@ protocol:
 
 NaiveProxy implements HTTP/2 CONNECT with padding for censorship resistance. Should be used within TLS with `alpn_protocols: ["h2"]`.
 
+### TPROXY (transparent proxy, Linux-only)
+
+Accepts traffic redirected to shoes by `iptables/nftables -j TPROXY` + `ip rule`.
+The original destination is recovered from the kernel and forwarded through
+the outbound proxy chain.
+
+```yaml
+protocol:
+  type: tproxy
+  tcp_enabled: true   # default true
+  udp_enabled: true   # default true
+```
+
+Requires:
+- **Linux** with `CAP_NET_ADMIN` (or root) on the shoes process.
+- `iptables -t mangle -j TPROXY` (or nftables equivalent) and an `ip rule`
+  + `ip route` pair pointing the marked traffic at the local loopback.
+
+See `examples/tproxy.yaml` for a complete worked example, including the
+required iptables setup.
+
 ## TUN Config
 
 TUN (network TUNnel) devices operate at the IP layer (Layer 3), allowing shoes to act as a transparent VPN.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ shoes is a high-performance multi-protocol proxy server written in Rust.
 - **TUIC v5**
 - **AnyTLS**
 - **NaiveProxy**
+- **TPROXY** (Linux transparent proxy, TCP + UDP)
 - **H2MUX** (supported with VMess, VLESS, Trojan, Shadowsocks, Snell)
 
 ### Transport Protocols

--- a/examples/tproxy.yaml
+++ b/examples/tproxy.yaml
@@ -4,8 +4,37 @@
 # kernel (via iptables/nftables + ip rule), shoes recovers the original
 # destination and forwards it through the outbound chain.
 #
-# IMPORTANT: tproxy listeners require CAP_NET_ADMIN (or root).
-# Run with: sudo shoes examples/tproxy.yaml
+# ---------------------------------------------------------------------------
+# Privileges
+# ---------------------------------------------------------------------------
+# Setting IP_TRANSPARENT on a socket is a kernel-side privileged operation.
+# The kernel accepts EITHER CAP_NET_RAW or CAP_NET_ADMIN — prefer CAP_NET_RAW
+# (narrower scope: no right to reconfigure interfaces, routes, netfilter, etc.).
+#
+# Quick start (development):
+#   sudo shoes examples/tproxy.yaml
+#
+# Single-binary capability (no sudo at runtime):
+#   sudo setcap cap_net_raw=+ep /usr/local/bin/shoes
+#   shoes examples/tproxy.yaml
+#
+# systemd (recommended for production — runs as unprivileged user):
+#   # /etc/systemd/system/shoes.service
+#   [Unit]
+#   Description=shoes proxy
+#   After=network.target
+#
+#   [Service]
+#   ExecStart=/usr/local/bin/shoes /etc/shoes/tproxy.yaml
+#   User=shoes
+#   Group=shoes
+#   AmbientCapabilities=CAP_NET_RAW
+#   CapabilityBoundingSet=CAP_NET_RAW
+#   NoNewPrivileges=true
+#   Restart=on-failure
+#
+#   [Install]
+#   WantedBy=multi-user.target
 #
 # ---------------------------------------------------------------------------
 # Kernel-side setup (run once, as root):

--- a/examples/tproxy.yaml
+++ b/examples/tproxy.yaml
@@ -33,6 +33,4 @@
   rules:
     - masks: "0.0.0.0/0"
       action: allow
-      client_chain:
-        protocol:
-          type: direct
+      client_chain: direct

--- a/examples/tproxy.yaml
+++ b/examples/tproxy.yaml
@@ -1,0 +1,38 @@
+# TPROXY Inbound Example (Linux-only)
+#
+# TPROXY is a transparent proxy mode: traffic is redirected to shoes by the
+# kernel (via iptables/nftables + ip rule), shoes recovers the original
+# destination and forwards it through the outbound chain.
+#
+# IMPORTANT: tproxy listeners require CAP_NET_ADMIN (or root).
+# Run with: sudo shoes examples/tproxy.yaml
+#
+# ---------------------------------------------------------------------------
+# Kernel-side setup (run once, as root):
+# ---------------------------------------------------------------------------
+# # Mark and route packets destined for proxied IPs into a local table.
+# ip rule add fwmark 1 lookup 100
+# ip route add local 0.0.0.0/0 dev lo table 100
+#
+# # iptables rules: redirect TCP+UDP via TPROXY to port 7895.
+# iptables -t mangle -N SHOES
+# iptables -t mangle -A SHOES -d 127.0.0.0/8 -j RETURN
+# iptables -t mangle -A SHOES -d 10.0.0.0/8 -j RETURN
+# iptables -t mangle -A SHOES -d 192.168.0.0/16 -j RETURN
+# iptables -t mangle -A SHOES -d 172.16.0.0/12 -j RETURN
+# iptables -t mangle -A SHOES -p tcp -j TPROXY --on-port 7895 --tproxy-mark 1
+# iptables -t mangle -A SHOES -p udp -j TPROXY --on-port 7895 --tproxy-mark 1
+# iptables -t mangle -A PREROUTING -j SHOES
+# ---------------------------------------------------------------------------
+
+- address: "0.0.0.0:7895"
+  protocol:
+    type: tproxy
+    tcp_enabled: true
+    udp_enabled: true
+  rules:
+    - masks: "0.0.0.0/0"
+      action: allow
+      client_chain:
+        protocol:
+          type: direct

--- a/src/address.rs
+++ b/src/address.rs
@@ -129,6 +129,14 @@ impl NetLocation {
         Self { address, port }
     }
 
+    pub fn from_socket_addr(sa: std::net::SocketAddr) -> Self {
+        let address = match sa.ip() {
+            std::net::IpAddr::V4(a) => Address::Ipv4(a),
+            std::net::IpAddr::V6(a) => Address::Ipv6(a),
+        };
+        Self { address, port: sa.port() }
+    }
+
     pub fn components(&self) -> (&Address, u16) {
         (&self.address, self.port)
     }
@@ -684,5 +692,21 @@ mod tests {
             serde_yaml::from_str(&yaml_str).expect("Failed to deserialize NetLocationMask");
 
         assert_eq!(net_location_mask.to_string(), deserialized.to_string());
+    }
+
+    #[test]
+    fn from_socket_addr_ipv4() {
+        let sa: std::net::SocketAddr = "203.0.113.5:443".parse().unwrap();
+        let nl = NetLocation::from_socket_addr(sa);
+        assert_eq!(nl.port(), 443);
+        assert_eq!(nl.address(), &Address::Ipv4("203.0.113.5".parse().unwrap()));
+    }
+
+    #[test]
+    fn from_socket_addr_ipv6() {
+        let sa: std::net::SocketAddr = "[2001:db8::1]:8080".parse().unwrap();
+        let nl = NetLocation::from_socket_addr(sa);
+        assert_eq!(nl.port(), 8080);
+        assert_eq!(nl.address(), &Address::Ipv6("2001:db8::1".parse().unwrap()));
     }
 }

--- a/src/config/types/server.rs
+++ b/src/config/types/server.rs
@@ -780,6 +780,15 @@ pub enum ServerProxyConfig {
         #[serde(default = "default_true")]
         udp_enabled: bool,
     },
+    /// Linux transparent proxy inbound (TPROXY).
+    /// Accepts TCP/UDP traffic redirected via iptables `-j TPROXY` + `ip rule`.
+    /// Original destination is recovered from the kernel.
+    Tproxy {
+        #[serde(default = "default_true")]
+        tcp_enabled: bool,
+        #[serde(default = "default_true")]
+        udp_enabled: bool,
+    },
 }
 
 impl std::fmt::Display for ServerProxyConfig {
@@ -827,6 +836,7 @@ impl std::fmt::Display for ServerProxyConfig {
             Self::Mixed { .. } => write!(f, "Mixed (HTTP+SOCKS5)"),
             Self::Anytls { .. } => write!(f, "AnyTLS"),
             Self::Naiveproxy { .. } => write!(f, "NaiveProxy"),
+            Self::Tproxy { .. } => write!(f, "Tproxy"),
         }
     }
 }
@@ -1603,5 +1613,47 @@ client_chain:
         println!("Serialized:\n{serialized}");
         let deserialized: ShadowTlsRemoteHandshake = serde_yaml::from_str(&serialized).unwrap();
         assert_eq!(deserialized.client_chain.len(), original.client_chain.len());
+    }
+
+    #[test]
+    fn tproxy_default_yaml_roundtrip() {
+        let yaml = r#"
+address: "0.0.0.0:7895"
+protocol:
+  type: tproxy
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml).unwrap();
+        match cfg.protocol {
+            ServerProxyConfig::Tproxy { tcp_enabled, udp_enabled } => {
+                assert!(tcp_enabled);
+                assert!(udp_enabled);
+            }
+            _ => panic!("expected Tproxy variant"),
+        }
+    }
+
+    #[test]
+    fn tproxy_explicit_flags_yaml_roundtrip() {
+        let yaml = r#"
+address: "0.0.0.0:7895"
+protocol:
+  type: tproxy
+  tcp_enabled: true
+  udp_enabled: false
+"#;
+        let cfg: ServerConfig = serde_yaml::from_str(yaml).unwrap();
+        match cfg.protocol {
+            ServerProxyConfig::Tproxy { tcp_enabled, udp_enabled } => {
+                assert!(tcp_enabled);
+                assert!(!udp_enabled);
+            }
+            _ => panic!("expected Tproxy variant"),
+        }
+    }
+
+    #[test]
+    fn tproxy_display() {
+        let p = ServerProxyConfig::Tproxy { tcp_enabled: true, udp_enabled: true };
+        assert_eq!(format!("{p}"), "Tproxy");
     }
 }

--- a/src/config/types/server.rs
+++ b/src/config/types/server.rs
@@ -836,7 +836,7 @@ impl std::fmt::Display for ServerProxyConfig {
             Self::Mixed { .. } => write!(f, "Mixed (HTTP+SOCKS5)"),
             Self::Anytls { .. } => write!(f, "AnyTLS"),
             Self::Naiveproxy { .. } => write!(f, "NaiveProxy"),
-            Self::Tproxy { .. } => write!(f, "Tproxy"),
+            Self::Tproxy { .. } => write!(f, "TPROXY"),
         }
     }
 }
@@ -1654,6 +1654,6 @@ protocol:
     #[test]
     fn tproxy_display() {
         let p = ServerProxyConfig::Tproxy { tcp_enabled: true, udp_enabled: true };
-        assert_eq!(format!("{p}"), "Tproxy");
+        assert_eq!(format!("{p}"), "TPROXY");
     }
 }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -2701,6 +2701,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn tproxy_rejects_quic_transport() {
         let yaml = r#"
@@ -2718,6 +2719,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn tproxy_rejects_unix_socket_bind() {
         let yaml = r#"
@@ -2734,6 +2736,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn tproxy_rejects_both_disabled() {
         let yaml = r#"
@@ -2749,6 +2752,23 @@ mod tests {
             err.to_lowercase().contains("tcp_enabled") || err.to_lowercase().contains("udp_enabled"),
             "got: {err}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tproxy_rejects_quic_settings() {
+        let yaml = r#"
+- address: "0.0.0.0:7895"
+  quic_settings:
+    cert: "/tmp/does-not-exist.crt"
+    key: "/tmp/does-not-exist.key"
+  protocol:
+    type: tproxy
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let err = tproxy_err(configs);
+        assert!(err.to_lowercase().contains("tproxy"), "got: {err}");
+        assert!(err.to_lowercase().contains("quic_settings"), "got: {err}");
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -629,6 +629,45 @@ fn validate_server_config(
     rule_groups: &HashMap<String, Vec<RuleConfig>>,
     named_pems: &HashMap<String, String>,
 ) -> std::io::Result<()> {
+    // Tproxy-specific validation (fail fast before other checks)
+    if let ServerProxyConfig::Tproxy { tcp_enabled, udp_enabled } = &server_config.protocol {
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (tcp_enabled, udp_enabled); // silence unused warning on non-linux
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "tproxy protocol is only supported on Linux",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if server_config.transport != Transport::Tcp {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "tproxy protocol does not support quic transport",
+                ));
+            }
+            if matches!(server_config.bind_location, super::types::BindLocation::Path(_)) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "tproxy protocol cannot bind to a unix socket path",
+                ));
+            }
+            if server_config.quic_settings.is_some() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "tproxy protocol does not accept quic_settings",
+                ));
+            }
+            if !*tcp_enabled && !*udp_enabled {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "tproxy requires at least one of tcp_enabled or udp_enabled",
+                ));
+            }
+        }
+    }
+
     // First handle QUIC settings certificates
     if let Some(ref mut quic_settings) = server_config.quic_settings {
         embed_pem_from_map(&mut quic_settings.cert, named_pems);
@@ -2653,5 +2692,88 @@ mod tests {
             "error should mention group name: {}",
             err
         );
+    }
+
+    fn tproxy_err(configs: Vec<Config>) -> String {
+        match create_server_configs(configs) {
+            Ok(_) => panic!("expected validation error but got Ok"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn tproxy_rejects_quic_transport() {
+        let yaml = r#"
+- address: "0.0.0.0:7895"
+  transport: quic
+  protocol:
+    type: tproxy
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let err = tproxy_err(configs);
+        assert!(err.to_lowercase().contains("tproxy"), "got: {err}");
+        assert!(
+            err.to_lowercase().contains("quic") || err.to_lowercase().contains("transport"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn tproxy_rejects_unix_socket_bind() {
+        let yaml = r#"
+- path: "/tmp/foo.sock"
+  protocol:
+    type: tproxy
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let err = tproxy_err(configs);
+        assert!(err.to_lowercase().contains("tproxy"), "got: {err}");
+        assert!(
+            err.to_lowercase().contains("unix") || err.to_lowercase().contains("path"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn tproxy_rejects_both_disabled() {
+        let yaml = r#"
+- address: "0.0.0.0:7895"
+  protocol:
+    type: tproxy
+    tcp_enabled: false
+    udp_enabled: false
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let err = tproxy_err(configs);
+        assert!(
+            err.to_lowercase().contains("tcp_enabled") || err.to_lowercase().contains("udp_enabled"),
+            "got: {err}"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn tproxy_rejects_on_non_linux() {
+        let yaml = r#"
+- address: "0.0.0.0:7895"
+  protocol:
+    type: tproxy
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let err = tproxy_err(configs);
+        assert!(err.to_lowercase().contains("linux"), "got: {err}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tproxy_minimal_config_accepted() {
+        crate::thread_util::set_num_threads(1);
+        let yaml = r#"
+- address: "0.0.0.0:7895"
+  protocol:
+    type: tproxy
+"#;
+        let configs: Vec<Config> = serde_yaml::from_str(yaml).unwrap();
+        let _validated = create_server_configs(configs).expect("should validate");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,10 @@ pub mod logging;
 #[cfg(unix)]
 pub mod tun;
 
+/// Linux transparent proxy (TPROXY) inbound.
+#[cfg(target_os = "linux")]
+pub mod tproxy;
+
 /// FFI bindings for mobile platforms.
 #[cfg(any(target_os = "android", target_os = "ios", feature = "ffi"))]
 pub mod ffi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ mod trojan_handler;
 mod tuic_server;
 #[cfg(unix)]
 mod tun;
+#[cfg(target_os = "linux")]
+mod tproxy;
 mod udp_message_stream;
 mod uot;
 mod util;

--- a/src/tcp/tcp_server.rs
+++ b/src/tcp/tcp_server.rs
@@ -118,35 +118,10 @@ where
     server_handler.setup_server_stream(server_stream).await
 }
 
-pub async fn process_stream<AS>(
-    stream: AS,
-    server_handler: Arc<dyn TcpServerHandler>,
+pub async fn process_setup_result(
+    setup_result: TcpServerSetupResult,
     resolver: Arc<dyn Resolver>,
-) -> std::io::Result<()>
-where
-    AS: AsyncStream + 'static,
-{
-    let setup_server_stream_future = timeout(
-        Duration::from_secs(60),
-        setup_server_stream(stream, server_handler),
-    );
-
-    let setup_result = match setup_server_stream_future.await {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            return Err(std::io::Error::new(
-                e.kind(),
-                format!("failed to setup server stream: {e}"),
-            ));
-        }
-        Err(elapsed) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!("server setup timed out: {elapsed}"),
-            ));
-        }
-    };
-
+) -> std::io::Result<()> {
     match setup_result {
         TcpServerSetupResult::TcpForward {
             remote_location,
@@ -282,6 +257,38 @@ where
             Ok(())
         }
     }
+}
+
+pub async fn process_stream<AS>(
+    stream: AS,
+    server_handler: Arc<dyn TcpServerHandler>,
+    resolver: Arc<dyn Resolver>,
+) -> std::io::Result<()>
+where
+    AS: AsyncStream + 'static,
+{
+    let setup_server_stream_future = timeout(
+        Duration::from_secs(60),
+        setup_server_stream(stream, server_handler),
+    );
+
+    let setup_result = match setup_server_stream_future.await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            return Err(std::io::Error::new(
+                e.kind(),
+                format!("failed to setup server stream: {e}"),
+            ));
+        }
+        Err(elapsed) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("server setup timed out: {elapsed}"),
+            ));
+        }
+    };
+
+    process_setup_result(setup_result, resolver).await
 }
 
 pub async fn setup_client_tcp_stream(

--- a/src/tcp/tcp_server.rs
+++ b/src/tcp/tcp_server.rs
@@ -365,12 +365,10 @@ pub async fn start_servers(
             "TUN server is not supported on this platform",
         )),
         Config::Server(server_config) => {
-            #[cfg(target_os = "linux")]
             if matches!(server_config.protocol, crate::config::ServerProxyConfig::Tproxy { .. }) {
+                #[cfg(target_os = "linux")]
                 return crate::tproxy::start_tproxy_servers(server_config, resolver).await;
-            }
-            #[cfg(not(target_os = "linux"))]
-            if matches!(server_config.protocol, crate::config::ServerProxyConfig::Tproxy { .. }) {
+                #[cfg(not(target_os = "linux"))]
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Unsupported,
                     "tproxy protocol is only supported on Linux",

--- a/src/tcp/tcp_server.rs
+++ b/src/tcp/tcp_server.rs
@@ -364,7 +364,20 @@ pub async fn start_servers(
             std::io::ErrorKind::Unsupported,
             "TUN server is not supported on this platform",
         )),
-        Config::Server(server_config) => start_tcp_or_quic_servers(server_config, resolver).await,
+        Config::Server(server_config) => {
+            #[cfg(target_os = "linux")]
+            if matches!(server_config.protocol, crate::config::ServerProxyConfig::Tproxy { .. }) {
+                return crate::tproxy::start_tproxy_servers(server_config, resolver).await;
+            }
+            #[cfg(not(target_os = "linux"))]
+            if matches!(server_config.protocol, crate::config::ServerProxyConfig::Tproxy { .. }) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "tproxy protocol is only supported on Linux",
+                ));
+            }
+            start_tcp_or_quic_servers(server_config, resolver).await
+        }
         _ => unreachable!("create_server_configs only returns Server and TunServer"),
     }
 }

--- a/src/tcp/tcp_server_handler_factory.rs
+++ b/src/tcp/tcp_server_handler_factory.rs
@@ -278,6 +278,9 @@ pub fn create_tcp_server_handler(
                  config validation should have rejected this"
             )
         }
+        ServerProxyConfig::Tproxy { .. } => {
+            unreachable!("tproxy handled by start_tproxy_servers; see Task 4/8")
+        }
         unknown_config => {
             panic!("Unsupported TCP proxy config: {unknown_config:?}")
         }

--- a/src/tcp/tcp_server_handler_factory.rs
+++ b/src/tcp/tcp_server_handler_factory.rs
@@ -279,7 +279,7 @@ pub fn create_tcp_server_handler(
             )
         }
         ServerProxyConfig::Tproxy { .. } => {
-            unreachable!("tproxy handled by start_tproxy_servers; see Task 4/8")
+            panic!("tproxy is handled by crate::tproxy::start_tproxy_servers, not the handler factory")
         }
         unknown_config => {
             panic!("Unsupported TCP proxy config: {unknown_config:?}")

--- a/src/tcp/tcp_server_handler_factory.rs
+++ b/src/tcp/tcp_server_handler_factory.rs
@@ -279,7 +279,7 @@ pub fn create_tcp_server_handler(
             )
         }
         ServerProxyConfig::Tproxy { .. } => {
-            panic!("tproxy is handled by crate::tproxy::start_tproxy_servers, not the handler factory")
+            unreachable!("tproxy is dispatched by start_tproxy_servers and never reaches the handler factory")
         }
         unknown_config => {
             panic!("Unsupported TCP proxy config: {unknown_config:?}")

--- a/src/tproxy/cmsg.rs
+++ b/src/tproxy/cmsg.rs
@@ -1,0 +1,171 @@
+//! `recvmsg` with `IP_RECVORIGDSTADDR` / `IPV6_RECVORIGDSTADDR` cmsg parsing.
+
+// Functions are pub API consumed by Task 7; suppress dead-code lint until wiring is in place.
+#![allow(dead_code)]
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::os::fd::AsRawFd;
+
+use tokio::io::Interest;
+use tokio::net::UdpSocket;
+
+/// Max ancillary data we expect: room for one `sockaddr_in6` cmsg.
+/// Generously sized to absorb alignment + future options.
+const CMSG_BUF_SIZE: usize = 128;
+
+/// `recvmsg` from the socket, returning the bytes read, the peer (client_src),
+/// and the original destination decoded from `IP_RECVORIGDSTADDR` /
+/// `IPV6_RECVORIGDSTADDR` cmsg.
+pub async fn recv_with_orig_dst(
+    socket: &UdpSocket,
+    buf: &mut [u8],
+) -> io::Result<(usize, SocketAddr, SocketAddr)> {
+    loop {
+        socket.readable().await?;
+        match socket.try_io(Interest::READABLE, || recv_with_orig_dst_blocking(socket, buf)) {
+            Ok(v) => return Ok(v),
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn recv_with_orig_dst_blocking(
+    socket: &UdpSocket,
+    buf: &mut [u8],
+) -> io::Result<(usize, SocketAddr, SocketAddr)> {
+    let fd = socket.as_raw_fd();
+
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+
+    let mut src_storage: MaybeUninit<libc::sockaddr_in6> = MaybeUninit::zeroed();
+    let mut cmsg_buf = [0u8; CMSG_BUF_SIZE];
+
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_name = src_storage.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_buf.len() as _;
+
+    let n = unsafe { libc::recvmsg(fd, &mut msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let n = n as usize;
+
+    let client_src = sockaddr_to_socket_addr(
+        src_storage.as_ptr() as *const libc::sockaddr,
+        msg.msg_namelen,
+    )?;
+
+    let orig_dst = parse_orig_dst_cmsg(&msg)?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing orig_dst cmsg"))?;
+
+    Ok((n, client_src, orig_dst))
+}
+
+/// Walk cmsg headers via `CMSG_FIRSTHDR`/`CMSG_NXTHDR` and pull out the
+/// original destination if present.
+fn parse_orig_dst_cmsg(msg: &libc::msghdr) -> io::Result<Option<SocketAddr>> {
+    let mut cmsg = unsafe { libc_cmsg_firsthdr(msg) };
+    while !cmsg.is_null() {
+        let hdr = unsafe { *cmsg };
+        match (hdr.cmsg_level, hdr.cmsg_type) {
+            (libc::IPPROTO_IP, libc::IP_RECVORIGDSTADDR) => {
+                let data_ptr = unsafe { libc::CMSG_DATA(cmsg) } as *const libc::sockaddr_in;
+                let sin = unsafe { std::ptr::read_unaligned(data_ptr) };
+                let port = u16::from_be(sin.sin_port);
+                let addr = Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
+                return Ok(Some(SocketAddr::V4(SocketAddrV4::new(addr, port))));
+            }
+            (libc::IPPROTO_IPV6, libc::IPV6_RECVORIGDSTADDR) => {
+                let data_ptr = unsafe { libc::CMSG_DATA(cmsg) } as *const libc::sockaddr_in6;
+                let sin6 = unsafe { std::ptr::read_unaligned(data_ptr) };
+                let port = u16::from_be(sin6.sin6_port);
+                let addr = Ipv6Addr::from(sin6.sin6_addr.s6_addr);
+                return Ok(Some(SocketAddr::V6(SocketAddrV6::new(
+                    addr,
+                    port,
+                    u32::from_be(sin6.sin6_flowinfo),
+                    sin6.sin6_scope_id,
+                ))));
+            }
+            _ => {}
+        }
+        cmsg = unsafe { libc::CMSG_NXTHDR(msg, cmsg) };
+    }
+    Ok(None)
+}
+
+/// Shim for `CMSG_FIRSTHDR` (libc exposes `CMSG_NXTHDR` but not always `CMSG_FIRSTHDR`).
+#[inline]
+unsafe fn libc_cmsg_firsthdr(msg: &libc::msghdr) -> *mut libc::cmsghdr {
+    if msg.msg_controllen < std::mem::size_of::<libc::cmsghdr>() {
+        std::ptr::null_mut()
+    } else {
+        msg.msg_control as *mut libc::cmsghdr
+    }
+}
+
+fn sockaddr_to_socket_addr(
+    addr: *const libc::sockaddr,
+    len: libc::socklen_t,
+) -> io::Result<SocketAddr> {
+    let family = unsafe { (*addr).sa_family } as libc::c_int;
+    match family {
+        libc::AF_INET if (len as usize) >= std::mem::size_of::<libc::sockaddr_in>() => {
+            let sin = unsafe { std::ptr::read_unaligned(addr as *const libc::sockaddr_in) };
+            let ip = Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
+            Ok(SocketAddr::V4(SocketAddrV4::new(ip, u16::from_be(sin.sin_port))))
+        }
+        libc::AF_INET6 if (len as usize) >= std::mem::size_of::<libc::sockaddr_in6>() => {
+            let sin6 = unsafe { std::ptr::read_unaligned(addr as *const libc::sockaddr_in6) };
+            Ok(SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::from(sin6.sin6_addr.s6_addr),
+                u16::from_be(sin6.sin6_port),
+                u32::from_be(sin6.sin6_flowinfo),
+                sin6.sin6_scope_id,
+            )))
+        }
+        _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unexpected sockaddr family/len")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn loopback_recv_returns_client_src_and_orig_dst() {
+        use crate::tproxy::listener::new_tproxy_udp_socket;
+        use std::net::Ipv4Addr;
+
+        let recv = match new_tproxy_udp_socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)) {
+            Ok(s) => s,
+            Err(e) if matches!(e.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) => {
+                eprintln!("skipping: tproxy udp bind requires CAP_NET_ADMIN");
+                return;
+            }
+            Err(e) => panic!("udp bind failed: {e}"),
+        };
+        let bind_addr = recv.local_addr().unwrap();
+
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_addr = client.local_addr().unwrap();
+        client.send_to(b"ping", bind_addr).await.unwrap();
+
+        let mut buf = [0u8; 64];
+        let (n, peer, orig_dst) = recv_with_orig_dst(&recv, &mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping");
+        assert_eq!(peer.ip(), client_addr.ip());
+        assert_eq!(peer.port(), client_addr.port());
+        assert_eq!(orig_dst.port(), bind_addr.port());
+    }
+}

--- a/src/tproxy/cmsg.rs
+++ b/src/tproxy/cmsg.rs
@@ -1,8 +1,5 @@
 //! `recvmsg` with `IP_RECVORIGDSTADDR` / `IPV6_RECVORIGDSTADDR` cmsg parsing.
 
-// Functions are pub API consumed by Task 7; suppress dead-code lint until wiring is in place.
-#![allow(dead_code)]
-
 use std::io;
 use std::mem::MaybeUninit;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/src/tproxy/cmsg.rs
+++ b/src/tproxy/cmsg.rs
@@ -60,6 +60,12 @@ fn recv_with_orig_dst_blocking(
     }
     let n = n as usize;
 
+    if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+        return Err(io::Error::other(
+            "tproxy recvmsg control buffer truncated; orig_dst cmsg may be incomplete",
+        ));
+    }
+
     let client_src = sockaddr_to_socket_addr(
         src_storage.as_ptr() as *const libc::sockaddr,
         msg.msg_namelen,
@@ -85,7 +91,7 @@ fn parse_orig_dst_cmsg(msg: &libc::msghdr) -> io::Result<Option<SocketAddr>> {
                 let addr = Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
                 return Ok(Some(SocketAddr::V4(SocketAddrV4::new(addr, port))));
             }
-            (libc::IPPROTO_IPV6, libc::IPV6_RECVORIGDSTADDR) => {
+            (libc::IPPROTO_IPV6, libc::IPV6_ORIGDSTADDR) => {
                 let data_ptr = unsafe { libc::CMSG_DATA(cmsg) } as *const libc::sockaddr_in6;
                 let sin6 = unsafe { std::ptr::read_unaligned(data_ptr) };
                 let port = u16::from_be(sin6.sin6_port);
@@ -167,5 +173,6 @@ mod tests {
         assert_eq!(peer.ip(), client_addr.ip());
         assert_eq!(peer.port(), client_addr.port());
         assert_eq!(orig_dst.port(), bind_addr.port());
+        assert_eq!(orig_dst.ip(), bind_addr.ip());
     }
 }

--- a/src/tproxy/cmsg.rs
+++ b/src/tproxy/cmsg.rs
@@ -121,7 +121,7 @@ fn parse_orig_dst_cmsg(msg: &libc::msghdr) -> io::Result<Option<SocketAddr>> {
 /// Shim for `CMSG_FIRSTHDR` (libc exposes `CMSG_NXTHDR` but not always `CMSG_FIRSTHDR`).
 #[inline]
 unsafe fn libc_cmsg_firsthdr(msg: &libc::msghdr) -> *mut libc::cmsghdr {
-    if msg.msg_controllen < std::mem::size_of::<libc::cmsghdr>() {
+    if (msg.msg_controllen as usize) < std::mem::size_of::<libc::cmsghdr>() {
         std::ptr::null_mut()
     } else {
         msg.msg_control as *mut libc::cmsghdr

--- a/src/tproxy/cmsg.rs
+++ b/src/tproxy/cmsg.rs
@@ -12,6 +12,15 @@ use tokio::net::UdpSocket;
 /// Generously sized to absorb alignment + future options.
 const CMSG_BUF_SIZE: usize = 128;
 
+/// Alignment-correct backing storage for cmsg control data.
+/// `recvmsg` writes `cmsghdr` records into this; reading them via
+/// `*mut cmsghdr` would be UB if the buffer had only u8 alignment.
+#[repr(C)]
+union CmsgBuffer {
+    bytes: [u8; CMSG_BUF_SIZE],
+    _align: libc::cmsghdr,
+}
+
 /// `recvmsg` from the socket, returning the bytes read, the peer (client_src),
 /// and the original destination decoded from `IP_RECVORIGDSTADDR` /
 /// `IPV6_RECVORIGDSTADDR` cmsg.
@@ -41,15 +50,17 @@ fn recv_with_orig_dst_blocking(
     };
 
     let mut src_storage: MaybeUninit<libc::sockaddr_in6> = MaybeUninit::zeroed();
-    let mut cmsg_buf = [0u8; CMSG_BUF_SIZE];
+    // SAFETY: zeroed bytes are a valid bit-pattern for the bytes field; the
+    // union exists purely to give the byte buffer cmsghdr alignment.
+    let mut cmsg_buf = CmsgBuffer { bytes: [0u8; CMSG_BUF_SIZE] };
 
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
     msg.msg_name = src_storage.as_mut_ptr() as *mut libc::c_void;
     msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
-    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
-    msg.msg_controllen = cmsg_buf.len() as _;
+    msg.msg_control = unsafe { cmsg_buf.bytes.as_mut_ptr() } as *mut libc::c_void;
+    msg.msg_controllen = CMSG_BUF_SIZE as _;
 
     let n = unsafe { libc::recvmsg(fd, &mut msg, 0) };
     if n < 0 {

--- a/src/tproxy/listener.rs
+++ b/src/tproxy/listener.rs
@@ -66,7 +66,6 @@ pub fn new_tproxy_tcp_listener(bind: SocketAddr) -> std::io::Result<tokio::net::
     socket.bind(&SockAddr::from(bind))?;
     socket.listen(4096)?;
     let std_listener: std::net::TcpListener = socket.into();
-    std_listener.set_nonblocking(true)?;
     tokio::net::TcpListener::from_std(std_listener)
 }
 
@@ -80,7 +79,6 @@ pub fn new_tproxy_udp_socket(bind: SocketAddr) -> std::io::Result<tokio::net::Ud
     set_recv_orig_dst_addr(&socket, bind.is_ipv6())?;
     socket.bind(&SockAddr::from(bind))?;
     let std_sock: std::net::UdpSocket = socket.into();
-    std_sock.set_nonblocking(true)?;
     tokio::net::UdpSocket::from_std(std_sock)
 }
 
@@ -91,12 +89,11 @@ pub fn new_tproxy_udp_send_socket(orig_dst: SocketAddr) -> std::io::Result<tokio
     let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
     socket.set_nonblocking(true)?;
     socket.set_reuse_address(true)?;
-    // SO_REUSEPORT improves cache reuse across threads (Linux supports it on UDP).
+    // SO_REUSEPORT lets multiple per-orig_dst sockets coexist on the same local address.
     socket.set_reuse_port(true)?;
     set_ip_transparent(&socket, orig_dst.is_ipv6())?;
     socket.bind(&SockAddr::from(orig_dst))?;
     let std_sock: std::net::UdpSocket = socket.into();
-    std_sock.set_nonblocking(true)?;
     tokio::net::UdpSocket::from_std(std_sock)
 }
 

--- a/src/tproxy/listener.rs
+++ b/src/tproxy/listener.rs
@@ -1,9 +1,5 @@
 //! Socket factories that apply the IP_TRANSPARENT family of options.
 
-// Functions are pub API consumed by Task 8 (wiring); suppress dead-code lint
-// until that wiring is in place.
-#![allow(dead_code)]
-
 use std::net::SocketAddr;
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};

--- a/src/tproxy/listener.rs
+++ b/src/tproxy/listener.rs
@@ -103,7 +103,7 @@ mod tests {
         let listener = match new_tproxy_tcp_listener(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)) {
             Ok(l) => l,
             Err(e) if e.raw_os_error() == Some(libc::EPERM) => {
-                eprintln!("skipping: tproxy listener bind requires CAP_NET_ADMIN");
+                eprintln!("skipping: tproxy listener bind requires CAP_NET_RAW or CAP_NET_ADMIN");
                 return;
             }
             Err(e) => panic!("listener bind failed: {e}"),
@@ -125,7 +125,7 @@ mod tests {
         let socket = match new_tproxy_udp_socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)) {
             Ok(s) => s,
             Err(e) if e.raw_os_error() == Some(libc::EPERM) => {
-                eprintln!("skipping: tproxy udp bind requires CAP_NET_ADMIN");
+                eprintln!("skipping: tproxy udp bind requires CAP_NET_RAW or CAP_NET_ADMIN");
                 return;
             }
             Err(e) => panic!("udp bind failed: {e}"),

--- a/src/tproxy/listener.rs
+++ b/src/tproxy/listener.rs
@@ -1,0 +1,150 @@
+//! Socket factories that apply the IP_TRANSPARENT family of options.
+
+// Functions are pub API consumed by Task 8 (wiring); suppress dead-code lint
+// until that wiring is in place.
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+
+/// Set `IP_TRANSPARENT` (v4) or `IPV6_TRANSPARENT` (v6) on the socket.
+fn set_ip_transparent(socket: &Socket, is_ipv6: bool) -> std::io::Result<()> {
+    let fd = std::os::fd::AsRawFd::as_raw_fd(socket);
+    let on: libc::c_int = 1;
+    let (level, name) = if is_ipv6 {
+        (libc::IPPROTO_IPV6, libc::IPV6_TRANSPARENT)
+    } else {
+        (libc::IPPROTO_IP, libc::IP_TRANSPARENT)
+    };
+    let r = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            name,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&on) as libc::socklen_t,
+        )
+    };
+    if r != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Set `IP_RECVORIGDSTADDR` (v4) and/or `IPV6_RECVORIGDSTADDR` (v6) on a UDP socket.
+fn set_recv_orig_dst_addr(socket: &Socket, is_ipv6: bool) -> std::io::Result<()> {
+    let fd = std::os::fd::AsRawFd::as_raw_fd(socket);
+    let on: libc::c_int = 1;
+    let (level, name) = if is_ipv6 {
+        (libc::IPPROTO_IPV6, libc::IPV6_RECVORIGDSTADDR)
+    } else {
+        (libc::IPPROTO_IP, libc::IP_RECVORIGDSTADDR)
+    };
+    let r = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            name,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&on) as libc::socklen_t,
+        )
+    };
+    if r != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Create a TCP listener with `IP_TRANSPARENT` set, ready for `tokio::accept`.
+pub fn new_tproxy_tcp_listener(bind: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
+    let domain = if bind.is_ipv6() { Domain::IPV6 } else { Domain::IPV4 };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    set_ip_transparent(&socket, bind.is_ipv6())?;
+    socket.bind(&SockAddr::from(bind))?;
+    socket.listen(4096)?;
+    let std_listener: std::net::TcpListener = socket.into();
+    std_listener.set_nonblocking(true)?;
+    tokio::net::TcpListener::from_std(std_listener)
+}
+
+/// Create a UDP socket with `IP_TRANSPARENT` and `IP_RECVORIGDSTADDR` set.
+pub fn new_tproxy_udp_socket(bind: SocketAddr) -> std::io::Result<tokio::net::UdpSocket> {
+    let domain = if bind.is_ipv6() { Domain::IPV6 } else { Domain::IPV4 };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    set_ip_transparent(&socket, bind.is_ipv6())?;
+    set_recv_orig_dst_addr(&socket, bind.is_ipv6())?;
+    socket.bind(&SockAddr::from(bind))?;
+    let std_sock: std::net::UdpSocket = socket.into();
+    std_sock.set_nonblocking(true)?;
+    tokio::net::UdpSocket::from_std(std_sock)
+}
+
+/// Create a per-orig-dst send socket bound to `orig_dst` with `IP_TRANSPARENT`
+/// for spoofing the source of UDP replies back to the client.
+pub fn new_tproxy_udp_send_socket(orig_dst: SocketAddr) -> std::io::Result<tokio::net::UdpSocket> {
+    let domain = if orig_dst.is_ipv6() { Domain::IPV6 } else { Domain::IPV4 };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    // SO_REUSEPORT improves cache reuse across threads (Linux supports it on UDP).
+    socket.set_reuse_port(true)?;
+    set_ip_transparent(&socket, orig_dst.is_ipv6())?;
+    socket.bind(&SockAddr::from(orig_dst))?;
+    let std_sock: std::net::UdpSocket = socket.into();
+    std_sock.set_nonblocking(true)?;
+    tokio::net::UdpSocket::from_std(std_sock)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[tokio::test]
+    async fn tcp_listener_accepts_local_connection() {
+        let listener = match new_tproxy_tcp_listener(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)) {
+            Ok(l) => l,
+            Err(e) if e.raw_os_error() == Some(libc::EPERM) => {
+                eprintln!("skipping: tproxy listener bind requires CAP_NET_ADMIN");
+                return;
+            }
+            Err(e) => panic!("listener bind failed: {e}"),
+        };
+        let bind_addr = listener.local_addr().unwrap();
+
+        let connect = tokio::spawn(async move {
+            tokio::net::TcpStream::connect(bind_addr).await
+        });
+
+        let (server_stream, _peer) = listener.accept().await.unwrap();
+        let server_local = server_stream.local_addr().unwrap();
+        assert_eq!(server_local.port(), bind_addr.port());
+        let _ = connect.await.unwrap().expect("client connect");
+    }
+
+    #[tokio::test]
+    async fn udp_socket_round_trip_loopback() {
+        let socket = match new_tproxy_udp_socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)) {
+            Ok(s) => s,
+            Err(e) if e.raw_os_error() == Some(libc::EPERM) => {
+                eprintln!("skipping: tproxy udp bind requires CAP_NET_ADMIN");
+                return;
+            }
+            Err(e) => panic!("udp bind failed: {e}"),
+        };
+        let bind_addr = socket.local_addr().unwrap();
+
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.send_to(b"hello", bind_addr).await.unwrap();
+
+        let mut buf = [0u8; 64];
+        let (n, peer) = socket.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+        assert_eq!(peer.ip(), std::net::IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+}

--- a/src/tproxy/mod.rs
+++ b/src/tproxy/mod.rs
@@ -9,3 +9,4 @@
 
 pub mod cmsg;
 pub mod listener;
+pub mod udp_relay;

--- a/src/tproxy/mod.rs
+++ b/src/tproxy/mod.rs
@@ -10,3 +10,139 @@
 pub mod cmsg;
 pub mod listener;
 pub mod udp_relay;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use log::{debug, error, info};
+use tokio::task::JoinHandle;
+
+use crate::address::NetLocation;
+use crate::client_proxy_selector::ClientProxySelector;
+use crate::config::{BindLocation, ConfigSelection, ServerConfig, ServerProxyConfig, TcpConfig};
+use crate::resolver::Resolver;
+use crate::socket_util::set_tcp_keepalive;
+use crate::tcp::tcp_client_handler_factory::create_tcp_client_proxy_selector;
+use crate::tcp::tcp_handler::TcpServerSetupResult;
+use crate::tcp::tcp_server::process_setup_result;
+
+pub async fn start_tproxy_servers(
+    config: ServerConfig,
+    resolver: Arc<dyn Resolver>,
+) -> std::io::Result<Vec<JoinHandle<()>>> {
+    let (tcp_enabled, udp_enabled) = match &config.protocol {
+        ServerProxyConfig::Tproxy { tcp_enabled, udp_enabled } => (*tcp_enabled, *udp_enabled),
+        other => {
+            return Err(std::io::Error::other(format!(
+                "start_tproxy_servers called with non-tproxy protocol: {other}"
+            )));
+        }
+    };
+
+    let bind_addrs = match &config.bind_location {
+        BindLocation::Address(range) => range.to_socket_addrs()?,
+        BindLocation::Path(_) => {
+            return Err(std::io::Error::other(
+                "tproxy cannot use unix socket bind (should have been rejected during validation)",
+            ));
+        }
+    };
+
+    let rules = config
+        .rules
+        .clone()
+        .map(ConfigSelection::unwrap_config)
+        .into_vec();
+    assert!(!rules.is_empty(), "rules must contain at least the default direct allow");
+
+    let proxy_selector = Arc::new(create_tcp_client_proxy_selector(rules, resolver.clone()));
+    let tcp_cfg = config.tcp_settings.clone().unwrap_or_default();
+
+    let mut handles: Vec<JoinHandle<()>> = Vec::new();
+
+    for bind in bind_addrs {
+        if tcp_enabled {
+            let resolver = resolver.clone();
+            let proxy_selector = proxy_selector.clone();
+            let tcp_cfg = tcp_cfg.clone();
+            info!("tproxy TCP listening on {bind}");
+            handles.push(tokio::spawn(async move {
+                if let Err(e) = run_tproxy_tcp_server(bind, tcp_cfg, resolver, proxy_selector).await {
+                    error!("tproxy TCP server on {bind} exited: {e}");
+                }
+            }));
+        }
+        if udp_enabled {
+            let resolver = resolver.clone();
+            let proxy_selector = proxy_selector.clone();
+            info!("tproxy UDP listening on {bind}");
+            handles.push(tokio::spawn(async move {
+                if let Err(e) = run_tproxy_udp_server(bind, resolver, proxy_selector).await {
+                    error!("tproxy UDP server on {bind} exited: {e}");
+                }
+            }));
+        }
+    }
+
+    Ok(handles)
+}
+
+async fn run_tproxy_tcp_server(
+    bind: SocketAddr,
+    tcp_cfg: TcpConfig,
+    resolver: Arc<dyn Resolver>,
+    proxy_selector: Arc<ClientProxySelector>,
+) -> std::io::Result<()> {
+    let listener = listener::new_tproxy_tcp_listener(bind)?;
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!("tproxy accept on {bind}: {e}");
+                continue;
+            }
+        };
+        let orig_dst = match stream.local_addr() {
+            Ok(a) => a,
+            Err(e) => {
+                error!("tproxy local_addr on accepted {peer}: {e}");
+                continue;
+            }
+        };
+        if let Err(e) = set_tcp_keepalive(
+            &stream,
+            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(60),
+        ) {
+            error!("tproxy keepalive: {e}");
+        }
+        if tcp_cfg.no_delay && let Err(e) = stream.set_nodelay(true) {
+            error!("tproxy nodelay: {e}");
+        }
+        let resolver = resolver.clone();
+        let proxy_selector = proxy_selector.clone();
+        tokio::spawn(async move {
+            let setup = TcpServerSetupResult::TcpForward {
+                remote_location: NetLocation::from_socket_addr(orig_dst),
+                stream: Box::new(stream),
+                need_initial_flush: true,
+                connection_success_response: None,
+                initial_remote_data: None,
+                proxy_selector,
+            };
+            if let Err(e) = process_setup_result(setup, resolver).await {
+                debug!("tproxy {peer} -> {orig_dst}: {e}");
+            }
+        });
+    }
+}
+
+async fn run_tproxy_udp_server(
+    bind: SocketAddr,
+    resolver: Arc<dyn Resolver>,
+    proxy_selector: Arc<ClientProxySelector>,
+) -> std::io::Result<()> {
+    let socket = listener::new_tproxy_udp_socket(bind)?;
+    let relay = udp_relay::UdpRelay::new(socket, proxy_selector, resolver);
+    relay.run().await
+}

--- a/src/tproxy/mod.rs
+++ b/src/tproxy/mod.rs
@@ -1,0 +1,10 @@
+//! Linux transparent proxy (TPROXY) inbound.
+//!
+//! Accepts TCP and UDP traffic redirected via `iptables -j TPROXY` / `nftables`
+//! and `ip rule`. The original destination is recovered from the kernel
+//! (TCP: `getsockname` on the IP_TRANSPARENT-bound listener; UDP:
+//! `IP_RECVORIGDSTADDR`/`IPV6_RECVORIGDSTADDR` ancillary data).
+//!
+//! Linux-only.
+
+pub mod listener;

--- a/src/tproxy/mod.rs
+++ b/src/tproxy/mod.rs
@@ -39,6 +39,7 @@ pub async fn start_tproxy_servers(
         }
     };
 
+    let bind_display = config.bind_location.to_string();
     let bind_addrs = match &config.bind_location {
         BindLocation::Address(range) => range.to_socket_addrs()?,
         BindLocation::Path(_) => {
@@ -82,6 +83,13 @@ pub async fn start_tproxy_servers(
                 }
             }));
         }
+    }
+
+    if handles.is_empty() {
+        return Err(std::io::Error::other(format!(
+            "failed to start tproxy servers at {} (no resolved bind addresses or both tcp/udp disabled — should have been rejected by validation)",
+            bind_display
+        )));
     }
 
     Ok(handles)

--- a/src/tproxy/mod.rs
+++ b/src/tproxy/mod.rs
@@ -7,4 +7,5 @@
 //!
 //! Linux-only.
 
+pub mod cmsg;
 pub mod listener;

--- a/src/tproxy/udp_relay.rs
+++ b/src/tproxy/udp_relay.rs
@@ -1,7 +1,5 @@
 //! TPROXY UDP relay: session-based, with kernel-level source spoofing on reply.
 
-#![allow(dead_code)]
-
 use std::future::poll_fn;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;

--- a/src/tproxy/udp_relay.rs
+++ b/src/tproxy/udp_relay.rs
@@ -119,8 +119,23 @@ impl UdpRelay {
 
         let mut buf = vec![0u8; RECV_BUF_SIZE];
         loop {
-            let (n, client_src, orig_dst) =
-                recv_with_orig_dst(&self.recv_socket, &mut buf).await?;
+            let (n, client_src, orig_dst) = match recv_with_orig_dst(&self.recv_socket, &mut buf).await {
+                Ok(v) => v,
+                Err(e) => {
+                    // Per-packet anomalies (MSG_CTRUNC, missing cmsg) come back as InvalidData/Other.
+                    // Don't tear down the relay over one bad packet — log and keep going.
+                    match e.kind() {
+                        std::io::ErrorKind::InvalidData | std::io::ErrorKind::Other => {
+                            debug!("tproxy udp recv (dropping packet): {e}");
+                            continue;
+                        }
+                        _ => {
+                            warn!("tproxy udp recv failed: {e}");
+                            return Err(e);
+                        }
+                    }
+                }
+            };
             let key = SessionKey { client_src, orig_dst };
             let data = buf[..n].to_vec();
 
@@ -130,9 +145,25 @@ impl UdpRelay {
                 continue;
             }
 
-            match self.spawn_session(key.clone(), data).await {
-                Ok(Some(session)) => {
-                    self.sessions.insert(key, session);
+            // Borrow the initial packet's data once so we can hand it to whichever session wins the race.
+            let initial = data;
+            match self.spawn_session(key.clone(), initial.clone()).await {
+                Ok(Some(new_session)) => {
+                    use dashmap::mapref::entry::Entry;
+                    match self.sessions.entry(key) {
+                        Entry::Occupied(occupied) => {
+                            // Another packet for the same flow finished session setup first.
+                            // Hand our initial packet to the winning session; drop our newly-built
+                            // session (its Drop aborts the task we just spawned).
+                            let existing = occupied.get().clone();
+                            existing.touch();
+                            let _ = existing.tx.try_send(initial);
+                            drop(new_session);
+                        }
+                        Entry::Vacant(vacant) => {
+                            vacant.insert(new_session);
+                        }
+                    }
                 }
                 Ok(None) => {
                     // Blocked by rules — drop.

--- a/src/tproxy/udp_relay.rs
+++ b/src/tproxy/udp_relay.rs
@@ -1,0 +1,250 @@
+//! TPROXY UDP relay: session-based, with kernel-level source spoofing on reply.
+
+#![allow(dead_code)]
+
+use std::future::poll_fn;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use log::{debug, warn};
+use lru::LruCache;
+use parking_lot::Mutex;
+use tokio::io::ReadBuf;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::address::NetLocation;
+use crate::async_stream::AsyncMessageStream;
+use crate::client_proxy_selector::{ClientProxySelector, ConnectDecision};
+use crate::resolver::Resolver;
+use crate::tproxy::cmsg::recv_with_orig_dst;
+use crate::tproxy::listener::new_tproxy_udp_send_socket;
+
+const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const GC_INTERVAL: Duration = Duration::from_secs(10);
+const SEND_CACHE_CAP: usize = 1024;
+const RECV_BUF_SIZE: usize = 64 * 1024;
+const SESSION_QUEUE_DEPTH: usize = 64;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct SessionKey {
+    client_src: SocketAddr,
+    orig_dst: SocketAddr,
+}
+
+struct Session {
+    tx: mpsc::Sender<Vec<u8>>,
+    last_activity: Mutex<Instant>,
+    task: JoinHandle<()>,
+}
+
+impl Session {
+    fn touch(&self) {
+        *self.last_activity.lock() = Instant::now();
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// LRU cache of send sockets keyed by `orig_dst`. Each socket is bound to
+/// `orig_dst` with `IP_TRANSPARENT` so replies appear to come from the
+/// original destination the client meant to talk to.
+struct SendSocketCache {
+    inner: Mutex<LruCache<SocketAddr, Arc<UdpSocket>>>,
+}
+
+impl SendSocketCache {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(LruCache::new(NonZeroUsize::new(SEND_CACHE_CAP).unwrap())),
+        }
+    }
+
+    fn get_or_create(&self, orig_dst: SocketAddr) -> std::io::Result<Arc<UdpSocket>> {
+        if let Some(s) = self.inner.lock().get(&orig_dst).cloned() {
+            return Ok(s);
+        }
+        let socket = Arc::new(new_tproxy_udp_send_socket(orig_dst)?);
+        self.inner.lock().put(orig_dst, socket.clone());
+        Ok(socket)
+    }
+}
+
+pub struct UdpRelay {
+    recv_socket: Arc<UdpSocket>,
+    proxy_selector: Arc<ClientProxySelector>,
+    resolver: Arc<dyn Resolver>,
+    send_cache: Arc<SendSocketCache>,
+    sessions: Arc<DashMap<SessionKey, Arc<Session>>>,
+}
+
+impl UdpRelay {
+    pub fn new(
+        recv_socket: UdpSocket,
+        proxy_selector: Arc<ClientProxySelector>,
+        resolver: Arc<dyn Resolver>,
+    ) -> Self {
+        Self {
+            recv_socket: Arc::new(recv_socket),
+            proxy_selector,
+            resolver,
+            send_cache: Arc::new(SendSocketCache::new()),
+            sessions: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Run the relay until the recv socket errors (no shutdown signal — matches the
+    /// existing TCP server loop in tcp_server.rs).
+    pub async fn run(self) -> std::io::Result<()> {
+        let sessions_for_gc = self.sessions.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(GC_INTERVAL);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                let now = Instant::now();
+                sessions_for_gc
+                    .retain(|_, s| now.duration_since(*s.last_activity.lock()) < IDLE_TIMEOUT);
+            }
+        });
+
+        let mut buf = vec![0u8; RECV_BUF_SIZE];
+        loop {
+            let (n, client_src, orig_dst) =
+                recv_with_orig_dst(&self.recv_socket, &mut buf).await?;
+            let key = SessionKey { client_src, orig_dst };
+            let data = buf[..n].to_vec();
+
+            if let Some(session) = self.sessions.get(&key).map(|s| s.clone()) {
+                session.touch();
+                let _ = session.tx.try_send(data);
+                continue;
+            }
+
+            match self.spawn_session(key.clone(), data).await {
+                Ok(Some(session)) => {
+                    self.sessions.insert(key, session);
+                }
+                Ok(None) => {
+                    // Blocked by rules — drop.
+                }
+                Err(e) => {
+                    warn!(
+                        "tproxy udp session setup failed {} -> {}: {e}",
+                        key.client_src, key.orig_dst
+                    );
+                }
+            }
+        }
+    }
+
+    async fn spawn_session(
+        &self,
+        key: SessionKey,
+        initial: Vec<u8>,
+    ) -> std::io::Result<Option<Arc<Session>>> {
+        let net_loc = NetLocation::from_socket_addr(key.orig_dst);
+        let resolved = net_loc.into();
+        let decision = self.proxy_selector.judge(resolved, &self.resolver).await?;
+        let (chain_group, remote) = match decision {
+            ConnectDecision::Allow { chain_group, remote_location } => (chain_group, remote_location),
+            ConnectDecision::Block => {
+                debug!("tproxy udp blocked {} -> {}", key.client_src, key.orig_dst);
+                return Ok(None);
+            }
+        };
+
+        let outbound = chain_group
+            .connect_udp_bidirectional(&self.resolver, remote)
+            .await?;
+
+        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(SESSION_QUEUE_DEPTH);
+        let _ = tx.try_send(initial);
+
+        let send_cache = self.send_cache.clone();
+        let client_src = key.client_src;
+        let orig_dst = key.orig_dst;
+        let sessions = self.sessions.clone();
+        let key_for_cleanup = key.clone();
+
+        let task = tokio::spawn(async move {
+            let mut outbound: Box<dyn AsyncMessageStream> = outbound;
+            let mut read_buf = vec![0u8; RECV_BUF_SIZE];
+            loop {
+                tokio::select! {
+                    maybe_data = rx.recv() => {
+                        let Some(data) = maybe_data else { break };
+                        if let Err(e) = write_message_async(outbound.as_mut(), &data).await {
+                            debug!("tproxy outbound write {client_src} -> {orig_dst}: {e}");
+                            break;
+                        }
+                    }
+                    n = read_message_async(outbound.as_mut(), &mut read_buf) => {
+                        match n {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                let send = match send_cache.get_or_create(orig_dst) {
+                                    Ok(s) => s,
+                                    Err(e) => {
+                                        warn!("tproxy send-cache create {orig_dst}: {e}");
+                                        break;
+                                    }
+                                };
+                                if let Err(e) = send.send_to(&read_buf[..n], client_src).await {
+                                    debug!("tproxy reply send to {client_src}: {e}");
+                                    break;
+                                }
+                                if let Some(session) = sessions.get(&key_for_cleanup) {
+                                    session.touch();
+                                }
+                            }
+                            Err(e) => {
+                                debug!("tproxy outbound read {client_src} -> {orig_dst}: {e}");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            sessions.remove(&key_for_cleanup);
+        });
+
+        let session = Arc::new(Session {
+            tx,
+            last_activity: Mutex::new(Instant::now()),
+            task,
+        });
+        Ok(Some(session))
+    }
+}
+
+async fn write_message_async(
+    stream: &mut dyn AsyncMessageStream,
+    buf: &[u8],
+) -> std::io::Result<()> {
+    poll_fn(|cx| Pin::new(&mut *stream).poll_write_message(cx, buf)).await
+}
+
+async fn read_message_async(
+    stream: &mut dyn AsyncMessageStream,
+    buf: &mut [u8],
+) -> std::io::Result<usize> {
+    poll_fn(|cx| {
+        let mut read_buf = ReadBuf::new(buf);
+        match Pin::new(&mut *stream).poll_read_message(cx, &mut read_buf) {
+            std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(read_buf.filled().len())),
+            std::task::Poll::Ready(Err(e)) => std::task::Poll::Ready(Err(e)),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    })
+    .await
+}


### PR DESCRIPTION
# TPROXY inbound support (Linux)

Adds a new `tproxy` server protocol that accepts traffic redirected by the kernel via iptables/nftables + `IP_TRANSPARENT`, recovers the original destination, and forwards it through the normal outbound chain.

## What's included
- **Config**: new `ServerProxyConfig::Tproxy` variant with `tcp_enabled` / `udp_enabled` flags and validation (Linux-only, requires non-empty bind addresses, rejects nested protocols).
- **TCP**: `IP_TRANSPARENT` listener; original destination read from the accepted socket.
- **UDP**: session-based relay with `recvmsg` + cmsg parsing (`IP_ORIGDSTADDR` / `IPV6_ORIGDSTADDR`), source-address spoofing on replies via a per-destination send-socket cache, race-safe session insertion, and per-packet error tolerance.
- **Dispatcher**: `start_tproxy_servers` wired into startup.
- **Helpers**: `NetLocation::from_socket_addr`; `process_setup_result` extracted from `process_stream` for reuse.
- **Docs**: `examples/tproxy.yaml` with iptables/`ip rule` setup, plus a section in `CONFIG.md`.

## Notes
- Linux-only; listeners need `CAP_NET_RAW` (or `CAP_NET_ADMIN`, or root).
- musl build fix included.
- Cmsg control buffer is properly aligned; `MSG_CTRUNC` is detected and surfaced.
