### PR TITLE
resolver: cache all resolved addresses, not just the first

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -309,7 +309,12 @@ pub struct CachingNativeResolver {
 
 struct CachedResolveResult {
     timestamp: Instant,
-    addr: SocketAddr,
+    /// All addresses the hostname resolved to, in resolver order. The full list
+    /// is cached (not just the first) so a cache hit preserves the multi-address
+    /// connect fallback: callers like `SocketConnectorImpl::connect` try each
+    /// address in turn, so a dual-stack host whose first record is unreachable
+    /// still connects via a later record.
+    addrs: Vec<SocketAddr>,
 }
 
 impl std::fmt::Debug for CachingNativeResolver {
@@ -350,8 +355,11 @@ impl Resolver for CachingNativeResolver {
                 && Instant::now().duration_since(cached.timestamp)
                     <= Duration::from_secs(self.result_timeout_secs)
             {
-                let addr = cached.addr;
-                return Box::pin(async move { Ok(vec![addr]) });
+                // Return the full cached list (clone), not just the first
+                // address, so the caller's per-address connect fallback survives
+                // a cache hit (symmetric with the cache-miss path below).
+                let addrs = cached.addrs.clone();
+                return Box::pin(async move { Ok(addrs) });
             }
         }
 
@@ -372,12 +380,13 @@ impl Resolver for CachingNativeResolver {
                 )));
             }
 
-            // Cache the first result
+            // Cache the full resolved list so a later cache hit still feeds the
+            // multi-address connect fallback (e.g. dual-stack hosts).
             cache.lock().insert(
                 location,
                 CachedResolveResult {
                     timestamp: Instant::now(),
-                    addr: addrs[0],
+                    addrs: addrs.clone(),
                 },
             );
 
@@ -739,5 +748,24 @@ mod tests {
         let loc = NetLocation::new(Address::Ipv4("1.2.3.4".parse().unwrap()), 80);
         let result = resolver.resolve_location(&loc).await.unwrap();
         assert_eq!(result[0], "1.2.3.4:80".parse::<SocketAddr>().unwrap());
+    }
+
+    /// Regression: a `CachingNativeResolver` cache hit must return the same full
+    /// address list as the initial cache miss, not just the first address.
+    #[tokio::test]
+    async fn test_caching_native_resolver_hit_returns_full_list() {
+        let resolver = CachingNativeResolver::new();
+        let loc = NetLocation::new(Address::Hostname("localhost".to_string()), 9);
+
+        // First call: cache miss, returns the full resolved list.
+        let miss = resolver.resolve_location(&loc).await.unwrap();
+        assert!(!miss.is_empty(), "localhost must resolve to >= 1 address");
+
+        // Second call: cache hit, must return the same full list (not addrs[0]).
+        let hit = resolver.resolve_location(&loc).await.unwrap();
+        assert_eq!(
+            hit, miss,
+            "cache hit must return the full resolved list, not just the first address"
+        );
     }
 }


### PR DESCRIPTION
CachingNativeResolver (the default resolver when no DNS config is set) caches resolution results in CachedResolveResult, which stored only a single SocketAddr per entry.

The two cache paths were asymmetric:

- Cache miss: lookup_host returns the full Vec<SocketAddr>, and that full list is returned to the caller -- but only addrs[0] was stored in the cache.
- Cache hit: only the stored single address was returned (vec![cached.addr]).

So the first lookup of a host returned every resolved record, while every subsequent lookup within the TTL (default 1h) returned just one address.

This matters because the consumer SocketConnectorImpl::connect iterates the full address list with a real per-address connect fallback (both the TCP and QUIC transports try each address in turn until one succeeds). With a cache hit returning a single address, that fallback has nothing left to try. The practical failure: a dual-stack host whose first record is unreachable connects on the first attempt (miss -> full list -> fallback works) but fails on every subsequent attempt for the rest of the TTL (hit -> single dead address).

Fix: store the full Vec<SocketAddr> in the cache and clone it on a hit, so the hit path is symmetric with the miss path. TTL/expiry semantics are unchanged.

Single-address callers are unaffected: resolve_single_address and the separate ResolverCache still take addrs[0], and the head of the list is identical to the previously-cached single address. A focused regression test asserts that a cache hit returns the same full list as the initial miss.