### PR TITLE
hysteria2: bind UDP socket before spawning, return bind errors instead of panicking

### DIFF
--- a/src/hysteria2_server.rs
+++ b/src/hysteria2_server.rs
@@ -986,6 +986,18 @@ pub async fn start_hysteria2_server(
         let resolver = resolver.clone();
         let client_proxy_selector = client_proxy_selector.clone();
 
+        // Bind the UDP socket before spawning so a bind failure (e.g.
+        // EADDRINUSE on restart) is propagated to the caller via ? instead
+        // of panicking the spawned worker task. One bind per endpoint
+        // preserves the SO_REUSEPORT multi-endpoint behavior.
+        let socket2_socket = crate::socket_util::new_socket2_udp_socket_with_buffer_size(
+            bind_address.is_ipv6(),
+            None,
+            Some(bind_address),
+            true,
+            Some(8_625_000),
+        )?;
+
         let join_handle = tokio::spawn(async move {
             let mut server_config = quinn::ServerConfig::with_crypto(quic_server_config);
 
@@ -1012,22 +1024,18 @@ pub async fn start_hysteria2_server(
 
             // Use 7.5MB socket buffers for high-throughput QUIC (8.625MB on BSD for 15% kernel overhead)
             // https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-            let socket2_socket = crate::socket_util::new_socket2_udp_socket_with_buffer_size(
-                bind_address.is_ipv6(),
-                None,
-                Some(bind_address),
-                true,
-                Some(8_625_000),
-            )
-            .unwrap();
-
-            let endpoint = quinn::Endpoint::new(
+            let endpoint = match quinn::Endpoint::new(
                 quinn::EndpointConfig::default(),
                 Some(server_config),
                 socket2_socket.into(),
                 Arc::new(quinn::TokioRuntime),
-            )
-            .unwrap();
+            ) {
+                Ok(endpoint) => endpoint,
+                Err(e) => {
+                    error!("Failed to create hysteria2 quinn endpoint: {e}");
+                    return;
+                }
+            };
 
             while let Some(conn) = endpoint.accept().await {
                 let cloned_selector = client_proxy_selector.clone();


### PR DESCRIPTION
start_hysteria2_server returns io::Result<Vec<JoinHandle<()>>>, but the per-endpoint loop did the UDP socket bind and the quinn endpoint creation inside tokio::spawn(async move { ... }) and .unwrap()d both.

The function pushes the join handles and returns Ok to its caller before any spawned task body runs. So a bind failure -- e.g. EADDRINUSE during a restart or migration -- did not surface as the io::Error the signature already allows; it panicked a worker thread while the caller had already observed a successful start.

Fix:

- Hoist the UDP socket bind out of the spawned task to before tokio::spawn, still inside the for _ in 0..num_endpoints loop (one bind per endpoint, preserving the SO_REUSEPORT multi-endpoint behavior), and propagate its error with ? so a bind failure is returned to the caller.
- Move the now-bound socket into the spawned task (captured by async move).
- For the quinn endpoint creation that remains inside the task, replace .unwrap() with log-and-return so it degrades gracefully instead of panicking.

No config or protocol change; pure robustness. The bind -- the hard failure case -- is now surfaced synchronously to the caller.