### PR TITLE
anytls: send stream SYNACK before dialing the upstream target

### DIFF
--- a/src/anytls/anytls_server_session.rs
+++ b/src/anytls/anytls_server_session.rs
@@ -774,6 +774,24 @@ impl AnyTlsSession {
                     remote_location
                 );
 
+                // Send the SYNACK *before* connecting to the upstream target.
+                //
+                // sing-box's AnyTLS client pools idle sessions and reuses them for
+                // later streams. Opening a stream on a reused session (sid >= 2) arms
+                // a 3s `synDone` watcher that CLOSES THE WHOLE SESSION if the SYNACK is
+                // late (see sing-anytls session OpenStream). A post-connect SYNACK on a
+                // high-RTT link plus variable connect latency can exceed 3s, so every
+                // reused session is killed and re-dialed -> pool churn -> upload
+                // collapses. Download is immune (first stream sid==1 arms no watcher).
+                //
+                // Acking at stream-open keeps the watcher window at ~1 RTT. If the
+                // connect then fails we report it with a second SYNACK carrying the
+                // error; the sing-box client maps the follow-up to closeWithError.
+                if let Err(e) = self.send_synack(stream_id, None).await {
+                    log::debug!("Failed to send early SYNACK for stream {}: {}", stream_id, e);
+                    // Continue anyway - client may be v1 (send_synack is a no-op there)
+                }
+
                 // Connect through the proxy chain
                 let client_result = match chain_group
                     .connect_tcp(remote_location, &self.resolver)
@@ -781,19 +799,14 @@ impl AnyTlsSession {
                 {
                     Ok(result) => result,
                     Err(e) => {
-                        // Send SYNACK with error message (protocol v2)
+                        // Already acked above; surface the failure so the client tears
+                        // the stream down promptly instead of waiting on a timeout.
                         let error_msg = format!("connect failed: {}", e);
                         let _ = self.send_synack(stream_id, Some(&error_msg)).await;
                         return Err(e);
                     }
                 };
                 let mut client_stream = client_result.client_stream;
-
-                // Send successful SYNACK (protocol v2)
-                if let Err(e) = self.send_synack(stream_id, None).await {
-                    log::debug!("Failed to send SYNACK for stream {}: {}", stream_id, e);
-                    // Continue anyway - client may be v1
-                }
 
                 log::debug!("AnyTLS stream {} connected to destination", stream_id);
 


### PR DESCRIPTION
## Summary

`handle_tcp_forward` sent the success SYNACK only **after** `chain_group.connect_tcp(...)` returned. This change moves the success SYNACK to **before** the upstream dial, keeping the connect-failure error SYNACK (now sent as a follow-up).

## Why

sing-box's AnyTLS client pools idle sessions and reuses them for later streams. When it opens a stream on a **reused** session (sid >= 2) it arms a 3-second `synDone` watcher that closes the **entire session** if the SYNACK is late (see sing-anytls `session.OpenStream`). A post-connect SYNACK on a high-RTT link, plus variable connect latency, can exceed that 3s budget, so every reused session gets killed and re-dialed -> session-pool churn -> upload throughput collapses. Downloads are immune because the first stream (sid == 1) arms no watcher.

Acking at stream-open bounds the watcher window to roughly one RTT regardless of connect latency.

## Trade-off (please weigh in)

The reference AnyTLS server (anytls-go / sing-anytls) sends its handshake report **after** the upstream dial; this change acks at stream-open instead.

- **Benefit:** bounds sing-box's 3s reused-session `synDone` watcher to ~1 RTT, preventing session-pool churn and upload collapse on high-RTT links.
- **Cost:** on a dial failure the client receives a success SYNACK followed by an error SYNACK. sing-box maps the follow-up to `closeWithError`, and the per-stream FIN still closes only that sub-stream — the session is unaffected. Clients that ignore a second SYNACK simply see the per-stream FIN, which is benign.

`send_synack` is already a v2-gated no-op for v1 peers, so v1 clients are unaffected.

An alternative, if you prefer to stay closer to the reference behaviour, is to drop the success ack at stream-open entirely (and rely only on the per-stream FIN). I'm happy to adjust to whichever you'd like.

## Testing

`cargo check` passes (only pre-existing warnings unrelated to this change).
