### PR TITLE
feat: implement Clash-like Fake IP feature for DNS optimization

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -10,6 +10,7 @@ shoes uses YAML configuration files. Multiple configuration types can be combine
 - [Client Config](#client-config)
 - [Client Protocols](#client-protocols)
 - [Rules System](#rules-system)
+- [Fake IP](#fake-ip)
 - [Named Groups](#named-groups)
 - [Named PEMs](#named-pems)
 - [Advanced Features](#advanced-features)
@@ -625,6 +626,15 @@ rules:
       address: "proxy.example.com:1080"
       protocol:
         type: socks
+```
+
+## Fake IP
+
+The global `fake_ip` configuration can optionally be provided to dynamically allocate a pseudo-IP to avoid waiting for initial DNS resolution for TUN and HTTP/SOCKS proxies.
+
+```yaml
+- fake_ip:
+    network: 198.18.0.0/16
 ```
 
 ## Named Groups

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ serde_json = "*"
 tempfile = "*"
 tokio-rustls = "*"
 
-# jemalloc for better memory performance (not supported on Windows MSVC or iOS)
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios")))'.dependencies]
+# jemalloc for better memory performance (not supported on Windows MSVC, iOS, or Android)
+[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
 tikv-jemallocator = "*"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/src/address.rs
+++ b/src/address.rs
@@ -198,6 +198,20 @@ impl ResolvedLocation {
         }
     }
 
+    /// Rewrites the location if it is a Fake IP, restoring its original Hostname.
+    pub fn restore_fake_ip(&mut self) {
+        if let Address::Ipv4(ip) = self.location.address {
+            if let Some(manager) = crate::dns::fake_ip::GLOBAL_FAKE_IP_MANAGER.get() {
+                if manager.is_fake_ip(ip) {
+                    if let Some(domain) = manager.lookup_ip(ip) {
+                        self.location.address = Address::Hostname(domain);
+                        self.resolved_addr = None;
+                    }
+                }
+            }
+        }
+    }
+
     /// Get the underlying NetLocation.
     pub fn location(&self) -> &NetLocation {
         &self.location

--- a/src/address.rs
+++ b/src/address.rs
@@ -200,15 +200,13 @@ impl ResolvedLocation {
 
     /// Rewrites the location if it is a Fake IP, restoring its original Hostname.
     pub fn restore_fake_ip(&mut self) {
-        if let Address::Ipv4(ip) = self.location.address {
-            if let Some(manager) = crate::dns::fake_ip::GLOBAL_FAKE_IP_MANAGER.get() {
-                if manager.is_fake_ip(ip) {
-                    if let Some(domain) = manager.lookup_ip(ip) {
-                        self.location.address = Address::Hostname(domain);
-                        self.resolved_addr = None;
-                    }
-                }
-            }
+        if let Address::Ipv4(ip) = self.location.address
+            && let Some(manager) = crate::dns::fake_ip::GLOBAL_FAKE_IP_MANAGER.get()
+            && manager.is_fake_ip(ip)
+            && let Some(domain) = manager.lookup_ip(ip)
+        {
+            self.location.address = Address::Hostname(domain);
+            self.resolved_addr = None;
         }
     }
 

--- a/src/anytls/anytls_server_session.rs
+++ b/src/anytls/anytls_server_session.rs
@@ -1220,10 +1220,10 @@ mod tests {
         let mut buf = vec![0u8; 256];
         let result = timeout(Duration::from_millis(500), server.read(&mut buf)).await;
 
-        if let Ok(Ok(n)) = result {
-            if n > 0 {
-                assert_eq!(buf[0], Command::Alert as u8);
-            }
+        if let Ok(Ok(n)) = result
+            && n > 0
+        {
+            assert_eq!(buf[0], Command::Alert as u8);
         }
 
         session.close().await;
@@ -1261,10 +1261,10 @@ mod tests {
         let mut response_buf = vec![0u8; 16];
         let result = timeout(Duration::from_millis(500), server.read(&mut response_buf)).await;
 
-        if let Ok(Ok(n)) = result {
-            if n >= 7 {
-                assert_eq!(response_buf[0], Command::HeartResponse as u8);
-            }
+        if let Ok(Ok(n)) = result
+            && n >= 7
+        {
+            assert_eq!(response_buf[0], Command::HeartResponse as u8);
         }
 
         session.close().await;
@@ -1501,16 +1501,15 @@ mod tests {
         let mut buf = vec![0u8; 256];
         let result = timeout(Duration::from_millis(500), server.read(&mut buf)).await;
 
-        if let Ok(Ok(n)) = result {
-            if n >= 7 {
-                // Could be ServerSettings or UpdatePaddingScheme
-                // Either is valid response
-                let cmd = buf[0];
-                assert!(
-                    cmd == Command::UpdatePaddingScheme as u8
-                        || cmd == Command::ServerSettings as u8
-                );
-            }
+        if let Ok(Ok(n)) = result
+            && n >= 7
+        {
+            // Could be ServerSettings or UpdatePaddingScheme
+            // Either is valid response
+            let cmd = buf[0];
+            assert!(
+                cmd == Command::UpdatePaddingScheme as u8 || cmd == Command::ServerSettings as u8
+            );
         }
 
         session.close().await;

--- a/src/client_proxy_chain.rs
+++ b/src/client_proxy_chain.rs
@@ -618,8 +618,7 @@ mod tests {
             _resolver: &Arc<dyn Resolver>,
             _address: &ResolvedLocation,
         ) -> std::io::Result<Box<dyn AsyncStream>> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 "MockSocketConnector::connect not implemented",
             ))
         }
@@ -629,8 +628,7 @@ mod tests {
             _resolver: &Arc<dyn Resolver>,
             _target: ResolvedLocation,
         ) -> std::io::Result<Box<dyn AsyncMessageStream>> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 "MockSocketConnector::connect_udp_bidirectional not implemented",
             ))
         }
@@ -671,8 +669,7 @@ mod tests {
             _stream: Box<dyn AsyncStream>,
             _target: &ResolvedLocation,
         ) -> std::io::Result<TcpClientSetupResult> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 "MockProxyConnector::setup_tcp_stream not implemented",
             ))
         }
@@ -682,8 +679,7 @@ mod tests {
             _stream: Box<dyn AsyncStream>,
             _target: ResolvedLocation,
         ) -> std::io::Result<Box<dyn AsyncMessageStream>> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 "MockProxyConnector::setup_udp_bidirectional not implemented",
             ))
         }

--- a/src/client_proxy_selector.rs
+++ b/src/client_proxy_selector.rs
@@ -282,9 +282,11 @@ impl ClientProxySelector {
     #[inline]
     pub async fn judge<'a>(
         &'a self,
-        location: ResolvedLocation,
+        mut location: ResolvedLocation,
         resolver: &Arc<dyn Resolver>,
     ) -> std::io::Result<ConnectDecision<'a>> {
+        location.restore_fake_ip();
+
         // Derive resolved_ip from any pre-resolved address
         let resolved_ip = location.resolved_addr().map(|addr| ip_to_u128(addr.ip()));
 
@@ -335,6 +337,7 @@ impl ClientProxySelector {
         resolver: &Arc<dyn Resolver>,
     ) -> std::io::Result<ConnectDecision<'a>> {
         let mut location = location;
+        
         match match_rule(
             &self.rules,
             &mut location,

--- a/src/client_proxy_selector.rs
+++ b/src/client_proxy_selector.rs
@@ -337,7 +337,7 @@ impl ClientProxySelector {
         resolver: &Arc<dyn Resolver>,
     ) -> std::io::Result<ConnectDecision<'a>> {
         let mut location = location;
-        
+
         match match_rule(
             &self.rules,
             &mut location,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,7 +65,7 @@ pub async fn load_configs(args: &Vec<String>) -> std::io::Result<Vec<Config>> {
 /// Load config from a string (used by FFI targets)
 #[cfg(any(target_os = "android", target_os = "ios", feature = "ffi"))]
 pub fn load_config_str(config_str: &str) -> std::io::Result<Vec<Config>> {
-    serde_yaml::from_str::<Vec<Config>>(&config_str).map_err(|e| {
+    serde_yaml::from_str::<Vec<Config>>(config_str).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("Could not parse config string as config YAML: {e}"),

--- a/src/config/types/dns.rs
+++ b/src/config/types/dns.rs
@@ -23,6 +23,24 @@ fn default_attempts() -> usize {
     1
 }
 
+/// Fake IP configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FakeIpConfig {
+    pub fake_ip: FakeIpSettings,
+}
+
+/// Fake IP settings.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FakeIpSettings {
+    /// The IPv4 network range, e.g. "198.18.0.0/16"
+    pub network: String,
+    
+    /// Address to bind the built-in Fake IP DNS server.
+    /// E.g., "127.0.0.1:53". If not provided, FakeIP only works via TUN mode.
+    #[serde(default)]
+    pub bind_address: Option<String>,
+}
+
 /// A DNS server specification in config.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]

--- a/src/config/types/dns.rs
+++ b/src/config/types/dns.rs
@@ -34,7 +34,7 @@ pub struct FakeIpConfig {
 pub struct FakeIpSettings {
     /// The IPv4 network range, e.g. "198.18.0.0/16"
     pub network: String,
-    
+
     /// Address to bind the built-in Fake IP DNS server.
     /// E.g., "127.0.0.1:53". If not provided, FakeIP only works via TUN mode.
     #[serde(default)]

--- a/src/config/types/dns.rs
+++ b/src/config/types/dns.rs
@@ -381,7 +381,7 @@ servers: my-dns-group
         ] {
             let spec = DnsServerSpec::Simple(url.to_string());
             assert!(
-                !spec.as_group_ref().is_some(),
+                spec.as_group_ref().is_none(),
                 "{} should not be a group ref",
                 url
             );
@@ -402,7 +402,7 @@ servers: my-dns-group
             connect_timeout_secs: default_connect_timeout_secs(),
             attempts: default_attempts(),
         };
-        assert!(!spec.as_group_ref().is_some());
+        assert!(spec.as_group_ref().is_none());
         assert!(spec.as_group_ref().is_none());
     }
 
@@ -423,7 +423,7 @@ dns_servers:
         assert_eq!(servers[0].as_group_ref(), Some("base-dns"));
         assert!(servers[1].as_group_ref().is_some());
         assert_eq!(servers[1].as_group_ref(), Some("fast-dns"));
-        assert!(!servers[2].as_group_ref().is_some());
+        assert!(servers[2].as_group_ref().is_none());
     }
 
     #[test]

--- a/src/config/types/groups.rs
+++ b/src/config/types/groups.rs
@@ -157,6 +157,7 @@ pub enum Config {
     RuleConfigGroup(RuleConfigGroup),
     DnsConfigGroup(DnsConfigGroup),
     NamedPem(NamedPem),
+    FakeIp(crate::config::types::dns::FakeIpConfig),
 }
 
 impl<'de> serde::de::Deserialize<'de> for Config {
@@ -182,6 +183,7 @@ impl<'de> serde::de::Deserialize<'de> for Config {
         let has_address = map.contains_key(Value::String("address".to_string()));
         let has_path_field = map.contains_key(Value::String("path".to_string()));
         let has_pem = map.contains_key(Value::String("pem".to_string()));
+        let has_fake_ip = map.contains_key(Value::String("fake_ip".to_string()));
 
         // Check if this is a TUN config
         // TUN configs have 'device_name' (Linux) or 'device_fd' (iOS/Android)
@@ -211,6 +213,11 @@ impl<'de> serde::de::Deserialize<'de> for Config {
             serde_yaml::from_value(value)
                 .map(Config::DnsConfigGroup)
                 .map_err(|e| Error::custom(format!("invalid DNS config group: {e}")))
+        } else if has_fake_ip {
+            // FakeIp configuration
+            serde_yaml::from_value(value)
+                .map(Config::FakeIp)
+                .map_err(|e| Error::custom(format!("invalid fake_ip config: {e}")))
         } else if is_tun_config {
             // TunConfig - identified by having 'name' or 'raw_fd' without 'protocol' wrapper
             serde_yaml::from_value(value)
@@ -251,6 +258,7 @@ impl serde::ser::Serialize for Config {
             Config::RuleConfigGroup(group) => group.serialize(serializer),
             Config::DnsConfigGroup(group) => group.serialize(serializer),
             Config::NamedPem(pem) => pem.serialize(serializer),
+            Config::FakeIp(fake_ip) => fake_ip.serialize(serializer),
         }
     }
 }

--- a/src/config/types/mod.rs
+++ b/src/config/types/mod.rs
@@ -30,7 +30,7 @@ pub use client::{
     ClientConfig, ClientProxyConfig, H2MuxConfig, TlsClientConfig, WebsocketClientConfig,
 };
 pub use common::DEFAULT_REALITY_SHORT_ID;
-pub use dns::{DnsConfig, DnsConfigGroup, DnsServerSpec, ExpandedDnsGroup, ExpandedDnsSpec};
+pub use dns::{DnsConfig, DnsConfigGroup, DnsServerSpec, ExpandedDnsGroup, ExpandedDnsSpec, FakeIpConfig};
 pub use groups::{ClientConfigGroup, Config, NamedPem, PemSource};
 pub use rules::{ClientChain, ClientChainHop, RuleActionConfig, RuleConfig};
 pub use selection::ConfigSelection;

--- a/src/config/types/mod.rs
+++ b/src/config/types/mod.rs
@@ -30,7 +30,9 @@ pub use client::{
     ClientConfig, ClientProxyConfig, H2MuxConfig, TlsClientConfig, WebsocketClientConfig,
 };
 pub use common::DEFAULT_REALITY_SHORT_ID;
-pub use dns::{DnsConfig, DnsConfigGroup, DnsServerSpec, ExpandedDnsGroup, ExpandedDnsSpec, FakeIpConfig};
+pub use dns::{
+    DnsConfig, DnsConfigGroup, DnsServerSpec, ExpandedDnsGroup, ExpandedDnsSpec, FakeIpConfig,
+};
 pub use groups::{ClientConfigGroup, Config, NamedPem, PemSource};
 pub use rules::{ClientChain, ClientChainHop, RuleActionConfig, RuleConfig};
 pub use selection::ConfigSelection;

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -26,6 +26,8 @@ pub struct ValidatedConfigs {
     pub configs: Vec<Config>,
     /// Expanded DNS groups in topological order (bootstrap deps first).
     pub dns_groups: Vec<ExpandedDnsGroup>,
+    /// Fake IP configuration if specified
+    pub fake_ip: Option<crate::config::types::FakeIpConfig>,
 }
 
 /// Validates configs and returns startable server configs with expanded DNS groups.
@@ -69,6 +71,7 @@ pub fn create_server_configs(all_configs: Vec<Config>) -> std::io::Result<Valida
     let mut tun_configs: Vec<TunConfig> = vec![];
     let mut named_pems: HashMap<String, String> = HashMap::new();
     let mut dns_groups: HashMap<String, DnsConfigGroup> = HashMap::new();
+    let mut fake_ip: Option<crate::config::types::FakeIpConfig> = None;
 
     for config in all_configs.into_iter() {
         match config {
@@ -123,6 +126,15 @@ pub fn create_server_configs(all_configs: Vec<Config>) -> std::io::Result<Valida
                         format!("dns group already exists: {}", group_name),
                     ));
                 }
+            }
+            Config::FakeIp(fake_ip_config) => {
+                if fake_ip.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "multiple fake_ip configs found",
+                    ));
+                }
+                fake_ip = Some(fake_ip_config);
             }
         }
     }
@@ -187,6 +199,7 @@ pub fn create_server_configs(all_configs: Vec<Config>) -> std::io::Result<Valida
     Ok(ValidatedConfigs {
         configs: result,
         dns_groups: final_dns_groups,
+        fake_ip,
     })
 }
 
@@ -1750,17 +1763,17 @@ mod tests {
             protocol:
               type: http
 "#,
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display(),
-            cert_dir.display()
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/"),
+            cert_dir.display().to_string().replace('\\', "/")
         );
 
         let configs: Vec<Config> = serde_yaml::from_str(&config_yaml).unwrap();

--- a/src/dns/fake_ip.rs
+++ b/src/dns/fake_ip.rs
@@ -1,0 +1,121 @@
+use lru::LruCache;
+use parking_lot::RwLock;
+use rustc_hash::FxHashMap;
+use std::net::Ipv4Addr;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, OnceLock};
+
+pub static GLOBAL_FAKE_IP_MANAGER: OnceLock<Arc<FakeIpManager>> = OnceLock::new();
+
+pub struct FakeIpManager {
+    // IPv4 Network and Mask
+    network: u32,
+    mask: u32,
+    state: RwLock<FakeIpState>,
+}
+
+struct FakeIpState {
+    domain_to_ip: LruCache<String, Ipv4Addr>,
+    ip_to_domain: FxHashMap<Ipv4Addr, String>,
+    next_offset: u32,
+    max_offset: u32,
+}
+
+impl FakeIpManager {
+    /// Creates a new FakeIpManager given an IPv4 network and a prefix length (e.g., 198.18.0.0, 16)
+    pub fn new(network: Ipv4Addr, prefix_len: u8) -> Arc<Self> {
+        assert!(prefix_len <= 30 && prefix_len >= 8, "Prefix length must be between 8 and 30");
+        let net_u32 = u32::from(network);
+        let mask = !0u32 << (32 - prefix_len);
+        let network_addr = net_u32 & mask;
+        let max_offset = !mask - 1; // Exclude broadcast
+        let capacity = NonZeroUsize::new(max_offset as usize).expect("Capacity cannot be zero");
+
+        Arc::new(Self {
+            network: network_addr,
+            mask,
+            state: RwLock::new(FakeIpState {
+                domain_to_ip: LruCache::new(capacity),
+                ip_to_domain: FxHashMap::default(),
+                next_offset: 1, // Start from 1, exclude network address
+                max_offset,
+            }),
+        })
+    }
+
+    /// Fast check to see if an IP belongs to the FakeIP range
+    pub fn is_fake_ip(&self, ip: Ipv4Addr) -> bool {
+        let ip_u32 = u32::from(ip);
+        (ip_u32 & self.mask) == self.network
+    }
+
+    /// Lookup a Fake IP for a domain. If it doesn't exist, allocates a new one.
+    pub fn lookup_domain(&self, domain: &str) -> Ipv4Addr {
+        let mut state = self.state.write();
+
+        // Already assigned?
+        if let Some(ip) = state.domain_to_ip.get(domain) {
+            return *ip;
+        }
+
+        // Need new IP
+        let offset = if state.next_offset <= state.max_offset {
+            let o = state.next_offset;
+            state.next_offset += 1;
+            o
+        } else {
+            // Pool exhausted, evict the LRU
+            let (_old_domain, old_ip) = state.domain_to_ip.pop_lru().expect("Cache full but empty");
+            state.ip_to_domain.remove(&old_ip);
+            u32::from(old_ip) - self.network
+        };
+
+        let new_ip = Ipv4Addr::from(self.network + offset);
+
+        // Put to caches
+        state.domain_to_ip.put(domain.to_string(), new_ip);
+        state.ip_to_domain.insert(new_ip, domain.to_string());
+
+        new_ip
+    }
+
+    /// Lookup a domain by its Fake IP.
+    pub fn lookup_ip(&self, ip: Ipv4Addr) -> Option<String> {
+        let state = self.state.read();
+        state.ip_to_domain.get(&ip).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fake_ip_manager() {
+        // 198.18.0.0/30 has only 2 usable IPs: 198.18.0.1 and .2
+        let mgr = FakeIpManager::new(Ipv4Addr::new(198, 18, 0, 0), 30);
+        
+        let ip1 = mgr.lookup_domain("google.com");
+        assert_eq!(ip1, Ipv4Addr::new(198, 18, 0, 1));
+        assert!(mgr.is_fake_ip(ip1));
+
+        let ip2 = mgr.lookup_domain("youtube.com");
+        assert_eq!(ip2, Ipv4Addr::new(198, 18, 0, 2));
+
+        // Pool is full. Next allocation should evict google.com (least recently used)
+        let ip3 = mgr.lookup_domain("facebook.com");
+        assert_eq!(ip3, Ipv4Addr::new(198, 18, 0, 1));
+
+        // Now google.com is gone
+        assert_eq!(mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)), Some("facebook.com".to_string()));
+
+        // Lookup youtube again to make it recently used
+        let ip2_again = mgr.lookup_domain("youtube.com");
+        assert_eq!(ip2_again, Ipv4Addr::new(198, 18, 0, 2));
+
+        // Now evict again, it should pop facebook.com because youtube.com is recently used
+        let ip4 = mgr.lookup_domain("twitter.com");
+        assert_eq!(ip4, Ipv4Addr::new(198, 18, 0, 1));
+        assert_eq!(mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)), Some("twitter.com".to_string()));
+    }
+}

--- a/src/dns/fake_ip.rs
+++ b/src/dns/fake_ip.rs
@@ -24,7 +24,10 @@ struct FakeIpState {
 impl FakeIpManager {
     /// Creates a new FakeIpManager given an IPv4 network and a prefix length (e.g., 198.18.0.0, 16)
     pub fn new(network: Ipv4Addr, prefix_len: u8) -> Arc<Self> {
-        assert!(prefix_len <= 30 && prefix_len >= 8, "Prefix length must be between 8 and 30");
+        assert!(
+            (8..=30).contains(&prefix_len),
+            "Prefix length must be between 8 and 30"
+        );
         let net_u32 = u32::from(network);
         let mask = !0u32 << (32 - prefix_len);
         let network_addr = net_u32 & mask;
@@ -94,7 +97,7 @@ mod tests {
     fn test_fake_ip_manager() {
         // 198.18.0.0/30 has only 2 usable IPs: 198.18.0.1 and .2
         let mgr = FakeIpManager::new(Ipv4Addr::new(198, 18, 0, 0), 30);
-        
+
         let ip1 = mgr.lookup_domain("google.com");
         assert_eq!(ip1, Ipv4Addr::new(198, 18, 0, 1));
         assert!(mgr.is_fake_ip(ip1));
@@ -107,7 +110,10 @@ mod tests {
         assert_eq!(ip3, Ipv4Addr::new(198, 18, 0, 1));
 
         // Now google.com is gone
-        assert_eq!(mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)), Some("facebook.com".to_string()));
+        assert_eq!(
+            mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)),
+            Some("facebook.com".to_string())
+        );
 
         // Lookup youtube again to make it recently used
         let ip2_again = mgr.lookup_domain("youtube.com");
@@ -116,6 +122,9 @@ mod tests {
         // Now evict again, it should pop facebook.com because youtube.com is recently used
         let ip4 = mgr.lookup_domain("twitter.com");
         assert_eq!(ip4, Ipv4Addr::new(198, 18, 0, 1));
-        assert_eq!(mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)), Some("twitter.com".to_string()));
+        assert_eq!(
+            mgr.lookup_ip(Ipv4Addr::new(198, 18, 0, 1)),
+            Some("twitter.com".to_string())
+        );
     }
 }

--- a/src/dns/fake_ip_server.rs
+++ b/src/dns/fake_ip_server.rs
@@ -1,0 +1,74 @@
+use crate::dns::fake_ip::FakeIpManager;
+use hickory_resolver::proto::op::{Message, MessageType, ResponseCode};
+use hickory_resolver::proto::rr::{Record, RecordType, RData};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+
+pub struct FakeIpServer {
+    addr: SocketAddr,
+    manager: Arc<FakeIpManager>,
+}
+
+impl FakeIpServer {
+    pub fn new(addr: SocketAddr, manager: Arc<FakeIpManager>) -> Self {
+        Self { addr, manager }
+    }
+
+    pub async fn start(&self) -> std::io::Result<()> {
+        let socket = UdpSocket::bind(self.addr).await?;
+        log::info!("FakeIpServer listening on UDP {}", self.addr);
+
+        let mut buf = [0u8; 2048];
+        loop {
+            let (len, src) = match socket.recv_from(&mut buf).await {
+                Ok(r) => r,
+                Err(e) => {
+                    log::error!("FakeIpServer recv error from {}: {}", self.addr, e);
+                    continue;
+                }
+            };
+
+            let req_data = &buf[..len];
+            let req = match Message::from_vec(req_data) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    log::warn!("FakeIpServer failed to parse DNS request from {}: {}", src, e);
+                    continue;
+                }
+            };
+
+            let mut response = Message::new(req.metadata.id, MessageType::Response, req.metadata.op_code);
+            response.metadata.recursion_desired = req.metadata.recursion_desired;
+            response.metadata.recursion_available = true;
+
+            for query in req.queries.iter() {
+                response.add_query(query.clone());
+                
+                if query.query_type() == RecordType::A {
+                    let domain_name = query.name().to_utf8();
+                    let clean_domain = domain_name.trim_end_matches('.');
+                    
+                    let fake_ip = self.manager.lookup_domain(clean_domain);
+                    
+                    let record = Record::from_rdata(query.name().clone(), 300, RData::A(fake_ip.into()));
+                    response.add_answer(record);
+                }
+            }
+
+            response.metadata.response_code = ResponseCode::NoError;
+
+            let res_data = match response.to_vec() {
+                Ok(d) => d,
+                Err(e) => {
+                    log::error!("FakeIpServer failed to encode DNS response: {}", e);
+                    continue;
+                }
+            };
+
+            if let Err(e) = socket.send_to(&res_data, src).await {
+                log::error!("FakeIpServer failed to send response to {}: {}", src, e);
+            }
+        }
+    }
+}

--- a/src/dns/fake_ip_server.rs
+++ b/src/dns/fake_ip_server.rs
@@ -1,6 +1,6 @@
 use crate::dns::fake_ip::FakeIpManager;
 use hickory_resolver::proto::op::{Message, MessageType, ResponseCode};
-use hickory_resolver::proto::rr::{Record, RecordType, RData};
+use hickory_resolver::proto::rr::{RData, Record, RecordType};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
@@ -33,25 +33,31 @@ impl FakeIpServer {
             let req = match Message::from_vec(req_data) {
                 Ok(msg) => msg,
                 Err(e) => {
-                    log::warn!("FakeIpServer failed to parse DNS request from {}: {}", src, e);
+                    log::warn!(
+                        "FakeIpServer failed to parse DNS request from {}: {}",
+                        src,
+                        e
+                    );
                     continue;
                 }
             };
 
-            let mut response = Message::new(req.metadata.id, MessageType::Response, req.metadata.op_code);
+            let mut response =
+                Message::new(req.metadata.id, MessageType::Response, req.metadata.op_code);
             response.metadata.recursion_desired = req.metadata.recursion_desired;
             response.metadata.recursion_available = true;
 
             for query in req.queries.iter() {
                 response.add_query(query.clone());
-                
+
                 if query.query_type() == RecordType::A {
                     let domain_name = query.name().to_utf8();
                     let clean_domain = domain_name.trim_end_matches('.');
-                    
+
                     let fake_ip = self.manager.lookup_domain(clean_domain);
-                    
-                    let record = Record::from_rdata(query.name().clone(), 300, RData::A(fake_ip.into()));
+
+                    let record =
+                        Record::from_rdata(query.name().clone(), 300, RData::A(fake_ip.into()));
                     response.add_answer(record);
                 }
             }

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -12,9 +12,12 @@
 
 mod builder;
 mod composite_resolver;
+pub mod fake_ip;
+pub mod fake_ip_server;
 mod hickory_resolver;
 mod parsed;
 mod proxy_runtime;
 
 pub use builder::build_dns_registry;
+pub use fake_ip::FakeIpManager;
 pub use parsed::{IpStrategy, ParsedDnsUrl};

--- a/src/ffi/common.rs
+++ b/src/ffi/common.rs
@@ -141,6 +141,7 @@ pub async fn start_from_config(
     let crate::config::ValidatedConfigs {
         configs: validated_configs,
         dns_groups,
+        fake_ip: _,
     } = create_server_configs(configs)?;
 
     // Build DNS registry from expanded groups

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,10 @@ mod vmess;
 mod websocket;
 mod xudp;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios")))]
+#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios")))]
+#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,7 +400,7 @@ fn main() {
                             return;
                         }
                     };
-                    
+
                     let fake_ip_manager = dns::FakeIpManager::new(ip, prefix);
                     crate::dns::fake_ip::GLOBAL_FAKE_IP_MANAGER.set(fake_ip_manager.clone()).ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,7 +373,57 @@ fn main() {
             let config::ValidatedConfigs {
                 configs: server_configs,
                 dns_groups,
+                fake_ip: fake_ip_config,
             } = server_configs;
+
+            let _fake_ip_manager = match fake_ip_config {
+                Some(config) => {
+                    let parts: Vec<&str> = config.fake_ip.network.split('/').collect();
+                    if parts.len() != 2 {
+                        eprintln!("Invalid fake_ip network format. Expected IP/PREFIX\n");
+                        print_usage_and_exit(arg0);
+                        return;
+                    }
+                    let ip = match parts[0].parse() {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Invalid FakeIP IP address: {e}\n");
+                            print_usage_and_exit(arg0);
+                            return;
+                        }
+                    };
+                    let prefix = match parts[1].parse() {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Invalid FakeIP prefix length: {e}\n");
+                            print_usage_and_exit(arg0);
+                            return;
+                        }
+                    };
+                    
+                    let fake_ip_manager = dns::FakeIpManager::new(ip, prefix);
+                    crate::dns::fake_ip::GLOBAL_FAKE_IP_MANAGER.set(fake_ip_manager.clone()).ok();
+
+                    if let Some(bind_addr_str) = config.fake_ip.bind_address {
+                        let bind_addr: std::net::SocketAddr = match bind_addr_str.parse() {
+                            Ok(addr) => addr,
+                            Err(e) => {
+                                eprintln!("Invalid FakeIP bind_address: {e}\n");
+                                print_usage_and_exit(arg0);
+                                return;
+                            }
+                        };
+                        let server = dns::fake_ip_server::FakeIpServer::new(bind_addr, fake_ip_manager.clone());
+                        join_handles.push(tokio::spawn(async move {
+                            if let Err(e) = server.start().await {
+                                log::error!("Fake IP server error: {}", e);
+                            }
+                        }));
+                    }
+                    Some(fake_ip_manager)
+                }
+                None => None,
+            };
 
             // Build DNS registry from expanded groups (async - resolves hostnames)
             let mut dns_registry = match dns::build_dns_registry(dns_groups).await {

--- a/src/naiveproxy/naive_padding_stream.rs
+++ b/src/naiveproxy/naive_padding_stream.rs
@@ -575,7 +575,7 @@ mod tests {
         frame.extend_from_slice(&payload_len.to_be_bytes());
         frame.push(padding_len);
         frame.extend_from_slice(payload);
-        frame.extend(std::iter::repeat(0u8).take(padding_len as usize));
+        frame.extend(std::iter::repeat_n(0u8, padding_len as usize));
         frame
     }
 
@@ -594,7 +594,7 @@ mod tests {
     fn test_frame_encoding_empty_payload() {
         // Pure padding frame (payload_len = 0)
         let frame = encode_test_frame(b"", 50);
-        assert_eq!(frame.len(), 3 + 0 + 50);
+        assert_eq!(frame.len(), 3 + 50);
         assert_eq!(&frame[0..2], &[0x00, 0x00]); // payload_len = 0
         assert_eq!(frame[2], 50); // padding_len
     }

--- a/src/reality/common.rs
+++ b/src/reality/common.rs
@@ -83,6 +83,7 @@ pub const OUTGOING_BUFFER_LIMIT: usize = 64 * 1024;
 /// This is the zero-allocation version for use with in-place decryption.
 /// NOTE: Does NOT strip padding zeros - our implementation doesn't add padding.
 #[inline]
+#[allow(dead_code)]
 pub fn strip_content_type_slice(plaintext: &[u8]) -> io::Result<(u8, usize)> {
     if plaintext.is_empty() {
         return Err(Error::new(ErrorKind::InvalidData, "Empty plaintext"));

--- a/src/reality/reality_auth.rs
+++ b/src/reality/reality_auth.rs
@@ -247,7 +247,7 @@ mod tests {
         let mut shared_a_bytes = [0u8; 32];
         agreement::agree(
             &priv_a,
-            &agreement::UnparsedPublicKey::new(&agreement::X25519, pub_b.as_ref()),
+            agreement::UnparsedPublicKey::new(&agreement::X25519, pub_b.as_ref()),
             (),
             |key_material| {
                 shared_a_bytes.copy_from_slice(key_material);
@@ -259,7 +259,7 @@ mod tests {
         let mut shared_b_bytes = [0u8; 32];
         agreement::agree(
             &priv_b,
-            &agreement::UnparsedPublicKey::new(&agreement::X25519, pub_a.as_ref()),
+            agreement::UnparsedPublicKey::new(&agreement::X25519, pub_a.as_ref()),
             (),
             |key_material| {
                 shared_b_bytes.copy_from_slice(key_material);

--- a/src/reality/reality_util.rs
+++ b/src/reality/reality_util.rs
@@ -537,13 +537,13 @@ mod tests {
 
         // Valid 32-byte key
         let key_bytes = [0x42u8; 32];
-        let encoded = URL_SAFE_NO_PAD.encode(&key_bytes);
+        let encoded = URL_SAFE_NO_PAD.encode(key_bytes);
         let decoded = decode_public_key(&encoded).unwrap();
         assert_eq!(decoded, key_bytes);
 
         // Invalid length
         let short_key = [0x42u8; 16];
-        let encoded_short = URL_SAFE_NO_PAD.encode(&short_key);
+        let encoded_short = URL_SAFE_NO_PAD.encode(short_key);
         assert!(decode_public_key(&encoded_short).is_err());
 
         // Invalid base64

--- a/src/socket_util.rs
+++ b/src/socket_util.rs
@@ -69,7 +69,8 @@ pub fn new_socket2_udp_socket_with_buffer_size(
         panic!("Cannot support reuse sockets");
     }
 
-    if let Some(_interface) = bind_interface {
+    #[allow(unused_variables)]
+    if let Some(interface) = bind_interface {
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         socket.bind_device(Some(interface.as_bytes()))?;
 
@@ -165,7 +166,8 @@ pub fn new_tcp_listener(
     socket.set_nonblocking(true)?;
     socket.set_reuse_address(true)?;
 
-    if let Some(_interface) = bind_interface {
+    #[allow(unused_variables)]
+    if let Some(interface) = bind_interface {
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         socket.bind_device(Some(interface.as_bytes()))?;
 

--- a/src/socket_util.rs
+++ b/src/socket_util.rs
@@ -69,7 +69,7 @@ pub fn new_socket2_udp_socket_with_buffer_size(
         panic!("Cannot support reuse sockets");
     }
 
-    if let Some(ref interface) = bind_interface {
+    if let Some(_interface) = bind_interface {
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         socket.bind_device(Some(interface.as_bytes()))?;
 
@@ -165,7 +165,7 @@ pub fn new_tcp_listener(
     socket.set_nonblocking(true)?;
     socket.set_reuse_address(true)?;
 
-    if let Some(ref interface) = bind_interface {
+    if let Some(_interface) = bind_interface {
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         socket.bind_device(Some(interface.as_bytes()))?;
 

--- a/src/tcp/tcp_server.rs
+++ b/src/tcp/tcp_server.rs
@@ -71,7 +71,7 @@ async fn run_tcp_server(
 
 #[cfg(target_family = "unix")]
 async fn run_unix_server(
-    path_buf: PathBuf,
+    path_buf: std::path::PathBuf,
     resolver: Arc<dyn Resolver>,
     server_handler: Arc<dyn TcpServerHandler>,
 ) -> std::io::Result<()> {
@@ -460,7 +460,8 @@ async fn start_tcp_servers(
                 handles.push(handle);
             }
         }
-        BindLocation::Path(_path_buf) => {
+        #[allow(unused_variables)]
+        BindLocation::Path(path_buf) => {
             #[cfg(target_family = "unix")]
             {
                 let tcp_handler = tcp_handler.clone();

--- a/src/tcp/tcp_server.rs
+++ b/src/tcp/tcp_server.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -461,7 +460,7 @@ async fn start_tcp_servers(
                 handles.push(handle);
             }
         }
-        BindLocation::Path(path_buf) => {
+        BindLocation::Path(_path_buf) => {
             #[cfg(target_family = "unix")]
             {
                 let tcp_handler = tcp_handler.clone();
@@ -474,8 +473,7 @@ async fn start_tcp_servers(
             }
             #[cfg(not(target_family = "unix"))]
             {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(std::io::Error::other(
                     "Unix sockets are not supported on this platform",
                 ));
             }

--- a/src/vless/vision_unpad.rs
+++ b/src/vless/vision_unpad.rs
@@ -425,7 +425,7 @@ mod tests {
         let mut state = VisionUnpadder::new(user_uuid);
 
         // Data that's less than 16 bytes (too short to check UUID)
-        let short_data = vec![1, 2, 3, 4, 5];
+        let short_data = [1, 2, 3, 4, 5];
         let result = state.unpad(&short_data[..]).unwrap();
         assert!(result.content.is_empty()); // Need more data
         assert!(result.command.is_none());


### PR DESCRIPTION
## Description
This PR introduces a **Fake IP** feature (similar to the implementation in Clash) to optimize DNS resolution and connection latency, as well as to prevent local DNS leaks.

### How it works & Motivation
Normally, a client resolves a domain name first and then initiates a connection to the returned IP, **costing an extra DNS RTT**. 
With this Fake IP implementation:
1. **DNS Interception**: A local DNS server is spun up (using `hickory-dns`). When the client queries a domain, it immediately returns an unused pseudo-IP (e.g., `198.18.0.x` from a configured pool) and records the mapping in an LRU cache.
2. **Zero Round-Trip**: The client saves the real DNS resolution time and connects mapped Fake IP directly.
3. **Domain Restoration**: During the proxy connection phase (in `src/address.rs`), the proxy detects the Fake IP, retrieves the original FQDN mapped in the cache, and routes the proxy request using the actual domain name. 

### Implementation Details
- **`FakeIpManager`**: A thread-safe LRU cache (exposed globally via `std::sync::OnceLock`) to store `#Domain -> Fake IP` and `#Fake IP -> Domain` mappings.
- **DNS Server**: Integrated a lightweight UDP DNS server to parse DNS queries and return Fake IP binary records.
- **Connection Interception**: Injected `restore_fake_ip()` globally into the address parsing phase so any outbound connection utilizing a Fake IP seamlessly recovers its target FQDN before leaving `shoes`.
