### PR TITLE
security: harden protocol parsing and resource limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,7 +2225,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shoes"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -2282,6 +2282,7 @@ dependencies = [
  "url",
  "webpki-roots",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shoes"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 license = "MIT"
 description = "A multi-protocol proxy server."
@@ -84,6 +84,7 @@ tun = { version = "*", features = ["async"] }
 url = "*"
 webpki-roots = { version = "*" }
 x509-parser = { version = "*", default-features = false, features = ["verify-aws"] }
+zeroize = "1"
 
 [dev-dependencies]
 rcgen = { version = "*", default-features = false, features = ["aws_lc_rs", "pem"] }

--- a/src/anytls/anytls_server_session.rs
+++ b/src/anytls/anytls_server_session.rs
@@ -33,6 +33,9 @@ const CONTROL_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 /// Prevents memory leaks from hung streams (slow DNS, stuck connections, etc.)
 const STREAM_HANDLER_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Maximum concurrently handled streams per AnyTLS session.
+const MAX_ANYTLS_STREAMS_PER_SESSION: usize = 256;
+
 /// AnyTLS Session manages multiplexed streams over a connection
 pub struct AnyTlsSession {
     /// Underlying connection (split into reader/writer)
@@ -370,6 +373,8 @@ impl AnyTlsSession {
 
                 // Check if stream already exists and register atomically
                 // This prevents race conditions with duplicate SYNs
+                let mut reject_reason = None;
+                let mut tasks = self.stream_tasks.lock().await;
                 let stream_opt = {
                     let mut streams = self.streams.write().await;
                     use std::collections::hash_map::Entry;
@@ -379,16 +384,26 @@ impl AnyTlsSession {
                             None
                         }
                         Entry::Vacant(entry) => {
-                            // Create new stream with bounded channel for backpressure
-                            let (data_tx, data_rx) = mpsc::channel(STREAM_CHANNEL_BUFFER);
-                            let stream = AnyTlsStream::new(
-                                stream_id,
-                                data_rx,
-                                self.outgoing_tx.clone(),
-                                Arc::clone(&self.is_closed),
-                            );
-                            entry.insert(data_tx);
-                            Some(stream)
+                            if tasks.len() >= MAX_ANYTLS_STREAMS_PER_SESSION {
+                                log::warn!(
+                                    "Rejecting AnyTLS stream {}: session stream limit reached ({})",
+                                    stream_id,
+                                    MAX_ANYTLS_STREAMS_PER_SESSION
+                                );
+                                reject_reason = Some("too many concurrent streams");
+                                None
+                            } else {
+                                // Create new stream with bounded channel for backpressure
+                                let (data_tx, data_rx) = mpsc::channel(STREAM_CHANNEL_BUFFER);
+                                let stream = AnyTlsStream::new(
+                                    stream_id,
+                                    data_rx,
+                                    self.outgoing_tx.clone(),
+                                    Arc::clone(&self.is_closed),
+                                );
+                                entry.insert(data_tx);
+                                Some(stream)
+                            }
                         }
                     }
                 };
@@ -430,8 +445,12 @@ impl AnyTlsSession {
                     });
 
                     // Track the task for cancellation on session close
-                    let mut tasks = self.stream_tasks.lock().await;
                     tasks.insert(stream_id, handle);
+                }
+                drop(tasks);
+
+                if let Some(reason) = reject_reason {
+                    self.send_synack(stream_id, Some(reason)).await?;
                 }
             }
 

--- a/src/config/types/client.rs
+++ b/src/config/types/client.rs
@@ -15,6 +15,8 @@ use super::server::WebsocketPingType;
 use super::shadowsocks::ShadowsocksConfig;
 use super::transport::{ClientQuicConfig, TcpConfig, Transport};
 
+const REDACTED: &str = "<redacted>";
+
 /// Configuration for h2mux (HTTP/2 multiplexing) on protocols that support it.
 ///
 /// H2MUX multiplexes multiple proxy streams over a single HTTP/2 connection,
@@ -306,7 +308,7 @@ impl Default for ClientConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ClientProxyConfig {
     Direct,
@@ -437,6 +439,122 @@ pub enum ClientProxyConfig {
     },
 }
 
+impl std::fmt::Debug for ClientProxyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientProxyConfig::Direct => f.write_str("Direct"),
+            ClientProxyConfig::Http {
+                username,
+                password,
+                resolve_hostname,
+            } => f
+                .debug_struct("Http")
+                .field("username", username)
+                .field("password", &password.as_ref().map(|_| REDACTED))
+                .field("resolve_hostname", resolve_hostname)
+                .finish(),
+            ClientProxyConfig::Socks { username, password } => f
+                .debug_struct("Socks")
+                .field("username", username)
+                .field("password", &password.as_ref().map(|_| REDACTED))
+                .finish(),
+            ClientProxyConfig::Shadowsocks {
+                config,
+                udp_enabled,
+            } => f
+                .debug_struct("Shadowsocks")
+                .field("config", config)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ClientProxyConfig::Snell {
+                config,
+                udp_enabled,
+            } => f
+                .debug_struct("Snell")
+                .field("config", config)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ClientProxyConfig::Vless {
+                udp_enabled, h2mux, ..
+            } => f
+                .debug_struct("Vless")
+                .field("user_id", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .field("h2mux", h2mux)
+                .finish(),
+            ClientProxyConfig::Trojan {
+                shadowsocks, h2mux, ..
+            } => f
+                .debug_struct("Trojan")
+                .field("password", &REDACTED)
+                .field("shadowsocks", shadowsocks)
+                .field("h2mux", h2mux)
+                .finish(),
+            ClientProxyConfig::Reality {
+                public_key,
+                sni_hostname,
+                cipher_suites,
+                vision,
+                protocol,
+                ..
+            } => f
+                .debug_struct("Reality")
+                .field("public_key", public_key)
+                .field("short_id", &REDACTED)
+                .field("sni_hostname", sni_hostname)
+                .field("cipher_suites", cipher_suites)
+                .field("vision", vision)
+                .field("protocol", protocol)
+                .finish(),
+            ClientProxyConfig::ShadowTls {
+                sni_hostname,
+                protocol,
+                ..
+            } => f
+                .debug_struct("ShadowTls")
+                .field("password", &REDACTED)
+                .field("sni_hostname", sni_hostname)
+                .field("protocol", protocol)
+                .finish(),
+            ClientProxyConfig::Tls(tls_config) => f.debug_tuple("Tls").field(tls_config).finish(),
+            ClientProxyConfig::Vmess {
+                cipher,
+                udp_enabled,
+                h2mux,
+                ..
+            } => f
+                .debug_struct("Vmess")
+                .field("cipher", cipher)
+                .field("user_id", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .field("h2mux", h2mux)
+                .finish(),
+            ClientProxyConfig::Websocket(ws_config) => {
+                f.debug_tuple("Websocket").field(ws_config).finish()
+            }
+            ClientProxyConfig::PortForward => f.write_str("PortForward"),
+            ClientProxyConfig::Anytls {
+                udp_enabled,
+                padding_scheme,
+                ..
+            } => f
+                .debug_struct("Anytls")
+                .field("password", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .field("padding_scheme", padding_scheme)
+                .finish(),
+            ClientProxyConfig::Naiveproxy {
+                username, padding, ..
+            } => f
+                .debug_struct("Naiveproxy")
+                .field("username", username)
+                .field("password", &REDACTED)
+                .field("padding", padding)
+                .finish(),
+        }
+    }
+}
+
 impl ClientProxyConfig {
     pub fn is_direct(&self) -> bool {
         matches!(self, ClientProxyConfig::Direct)
@@ -464,7 +582,7 @@ impl ClientProxyConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct TlsClientConfig {
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub verify: bool,
@@ -496,6 +614,22 @@ pub struct TlsClientConfig {
     pub vision: bool,
 
     pub protocol: Box<ClientProxyConfig>,
+}
+
+impl std::fmt::Debug for TlsClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TlsClientConfig")
+            .field("verify", &self.verify)
+            .field("server_fingerprints", &self.server_fingerprints)
+            .field("sni_hostname", &self.sni_hostname)
+            .field("alpn_protocols", &self.alpn_protocols)
+            .field("tls_buffer_size", &self.tls_buffer_size)
+            .field("key", &self.key.as_ref().map(|_| REDACTED))
+            .field("cert", &self.cert.as_ref().map(|_| "<present>"))
+            .field("vision", &self.vision)
+            .field("protocol", &self.protocol)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -539,6 +673,19 @@ mod tests {
             deserialized.protocol,
             ClientProxyConfig::Socks { .. }
         ));
+    }
+
+    #[test]
+    fn test_client_config_debug_redacts_secrets() {
+        let config = ClientProxyConfig::Socks {
+            username: Some("client_user".to_string()),
+            password: Some("client_pass".to_string()),
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("client_pass"));
     }
 
     #[test]

--- a/src/config/types/groups.rs
+++ b/src/config/types/groups.rs
@@ -11,6 +11,8 @@ use super::selection::ConfigSelection;
 use super::server::ServerConfig;
 use super::tun::TunConfig;
 
+const REDACTED: &str = "<redacted>";
+
 /// A named group of client proxies.
 ///
 /// Groups can reference other groups using `ConfigSelection::GroupName`.
@@ -31,16 +33,34 @@ pub struct RuleConfigGroup {
     pub rules: OneOrSome<RuleConfig>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NamedPem {
     pub pem: String, // The name identifier
     pub source: PemSource,
 }
 
-#[derive(Debug, Clone)]
+impl std::fmt::Debug for NamedPem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NamedPem")
+            .field("pem", &self.pem)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+#[derive(Clone)]
 pub enum PemSource {
     Path(String),
     Data(String),
+}
+
+impl std::fmt::Debug for PemSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PemSource::Path(path) => f.debug_tuple("Path").field(path).finish(),
+            PemSource::Data(_) => f.debug_tuple("Data").field(&REDACTED).finish(),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for NamedPem {
@@ -463,6 +483,19 @@ client_proxies:
             }
             _ => panic!("Expected Data source"),
         }
+    }
+
+    #[test]
+    fn test_named_pem_debug_redacts_inline_data() {
+        let pem = NamedPem {
+            pem: "server_key".to_string(),
+            source: PemSource::Data("inline-secret-key".to_string()),
+        };
+
+        let debug = format!("{pem:?}");
+
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("inline-secret-key"));
     }
 
     #[test]

--- a/src/config/types/server.rs
+++ b/src/config/types/server.rs
@@ -1,6 +1,6 @@
 //! Server configuration types.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,8 +14,10 @@ use super::selection::ConfigSelection;
 use super::shadowsocks::ShadowsocksConfig;
 use super::transport::{BindLocation, ServerQuicConfig, TcpConfig, Transport};
 
+const REDACTED: &str = "<redacted>";
+
 /// AnyTLS user configuration
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnyTlsUserConfig {
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -23,14 +25,33 @@ pub struct AnyTlsUserConfig {
     pub password: String,
 }
 
+impl fmt::Debug for AnyTlsUserConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnyTlsUserConfig")
+            .field("name", &self.name)
+            .field("password", &REDACTED)
+            .finish()
+    }
+}
+
 /// NaiveProxy user configuration
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NaiveUserConfig {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
     pub username: String,
     pub password: String,
+}
+
+impl fmt::Debug for NaiveUserConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NaiveUserConfig")
+            .field("name", &self.name)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .finish()
+    }
 }
 
 /// NaiveProxy fallback configuration for probe resistance
@@ -297,7 +318,7 @@ impl<'de> serde::de::Deserialize<'de> for ServerConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RealityServerConfig {
     /// X25519 private key (32 bytes, base64url encoded)
     pub private_key: String,
@@ -346,7 +367,25 @@ pub struct RealityServerConfig {
     pub override_rules: NoneOrSome<ConfigSelection<RuleConfig>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+impl fmt::Debug for RealityServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RealityServerConfig")
+            .field("private_key", &REDACTED)
+            .field("short_ids", &REDACTED)
+            .field("dest", &self.dest)
+            .field("max_time_diff", &self.max_time_diff)
+            .field("min_client_version", &self.min_client_version)
+            .field("max_client_version", &self.max_client_version)
+            .field("cipher_suites", &self.cipher_suites)
+            .field("vision", &self.vision)
+            .field("protocol", &self.protocol)
+            .field("dest_client_chain", &self.dest_client_chain)
+            .field("override_rules", &self.override_rules)
+            .finish()
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct TlsServerConfig {
     pub cert: String,
     pub key: String,
@@ -388,7 +427,22 @@ pub struct TlsServerConfig {
     pub override_rules: NoneOrSome<ConfigSelection<RuleConfig>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+impl fmt::Debug for TlsServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlsServerConfig")
+            .field("cert", &"<present>")
+            .field("key", &REDACTED)
+            .field("alpn_protocols", &self.alpn_protocols)
+            .field("client_ca_certs", &self.client_ca_certs)
+            .field("client_fingerprints", &self.client_fingerprints)
+            .field("vision", &self.vision)
+            .field("protocol", &self.protocol)
+            .field("override_rules", &self.override_rules)
+            .finish()
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ShadowTlsServerConfig {
     pub password: String,
     pub handshake: ShadowTlsServerHandshakeConfig,
@@ -397,7 +451,18 @@ pub struct ShadowTlsServerConfig {
     pub override_rules: NoneOrSome<ConfigSelection<RuleConfig>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+impl fmt::Debug for ShadowTlsServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShadowTlsServerConfig")
+            .field("password", &REDACTED)
+            .field("handshake", &self.handshake)
+            .field("protocol", &self.protocol)
+            .field("override_rules", &self.override_rules)
+            .finish()
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ShadowTlsLocalHandshake {
     pub cert: String,
@@ -420,6 +485,18 @@ pub struct ShadowTlsLocalHandshake {
         skip_serializing_if = "NoneOrSome::is_unspecified"
     )]
     pub client_fingerprints: NoneOrSome<String>,
+}
+
+impl fmt::Debug for ShadowTlsLocalHandshake {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShadowTlsLocalHandshake")
+            .field("cert", &"<present>")
+            .field("key", &REDACTED)
+            .field("alpn_protocols", &self.alpn_protocols)
+            .field("client_ca_certs", &self.client_ca_certs)
+            .field("client_fingerprints", &self.client_fingerprints)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -517,7 +594,7 @@ impl Serialize for ShadowTlsRemoteHandshake {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum ShadowTlsServerHandshakeConfig {
     // Do the handshake locally with the provided TLS config.
@@ -525,6 +602,19 @@ pub enum ShadowTlsServerHandshakeConfig {
     // the provided certificate must be signed by a trusted CA.
     Local(ShadowTlsLocalHandshake),
     Remote(ShadowTlsRemoteHandshake),
+}
+
+impl fmt::Debug for ShadowTlsServerHandshakeConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ShadowTlsServerHandshakeConfig::Local(handshake) => {
+                f.debug_tuple("Local").field(handshake).finish()
+            }
+            ShadowTlsServerHandshakeConfig::Remote(handshake) => {
+                f.debug_tuple("Remote").field(handshake).finish()
+            }
+        }
+    }
 }
 
 impl<'de> serde::de::Deserialize<'de> for ShadowTlsServerHandshakeConfig {
@@ -635,7 +725,7 @@ impl WebsocketPingType {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ServerProxyConfig {
     Http {
@@ -782,6 +872,140 @@ pub enum ServerProxyConfig {
     },
 }
 
+impl fmt::Debug for ServerProxyConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServerProxyConfig::Http { username, password } => f
+                .debug_struct("Http")
+                .field("username", username)
+                .field("password", &password.as_ref().map(|_| REDACTED))
+                .finish(),
+            ServerProxyConfig::Socks {
+                username,
+                password,
+                udp_enabled,
+            } => f
+                .debug_struct("Socks")
+                .field("username", username)
+                .field("password", &password.as_ref().map(|_| REDACTED))
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::Shadowsocks {
+                config,
+                udp_enabled,
+            } => f
+                .debug_struct("Shadowsocks")
+                .field("config", config)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::Snell {
+                cipher,
+                udp_enabled,
+                ..
+            } => f
+                .debug_struct("Snell")
+                .field("cipher", cipher)
+                .field("password", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::Vless {
+                udp_enabled,
+                fallback,
+                ..
+            } => f
+                .debug_struct("Vless")
+                .field("user_id", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .field("fallback", fallback)
+                .finish(),
+            ServerProxyConfig::Trojan { shadowsocks, .. } => f
+                .debug_struct("Trojan")
+                .field("password", &REDACTED)
+                .field("shadowsocks", shadowsocks)
+                .finish(),
+            ServerProxyConfig::Tls {
+                tls_targets,
+                default_tls_target,
+                shadowtls_targets,
+                reality_targets,
+                tls_buffer_size,
+            } => f
+                .debug_struct("Tls")
+                .field("tls_targets", tls_targets)
+                .field("default_tls_target", default_tls_target)
+                .field("shadowtls_targets", shadowtls_targets)
+                .field("reality_targets", reality_targets)
+                .field("tls_buffer_size", tls_buffer_size)
+                .finish(),
+            ServerProxyConfig::Vmess {
+                cipher,
+                udp_enabled,
+                ..
+            } => f
+                .debug_struct("Vmess")
+                .field("cipher", cipher)
+                .field("user_id", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::Anytls {
+                users,
+                padding_scheme,
+                udp_enabled,
+                fallback,
+            } => f
+                .debug_struct("Anytls")
+                .field("users", users)
+                .field("padding_scheme", padding_scheme)
+                .field("udp_enabled", udp_enabled)
+                .field("fallback", fallback)
+                .finish(),
+            ServerProxyConfig::Websocket { targets } => f
+                .debug_struct("Websocket")
+                .field("targets", targets)
+                .finish(),
+            ServerProxyConfig::PortForward { targets } => f
+                .debug_struct("PortForward")
+                .field("targets", targets)
+                .finish(),
+            ServerProxyConfig::Hysteria2 { udp_enabled, .. } => f
+                .debug_struct("Hysteria2")
+                .field("password", &REDACTED)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::TuicV5 {
+                zero_rtt_handshake, ..
+            } => f
+                .debug_struct("TuicV5")
+                .field("uuid", &REDACTED)
+                .field("password", &REDACTED)
+                .field("zero_rtt_handshake", zero_rtt_handshake)
+                .finish(),
+            ServerProxyConfig::Mixed {
+                username,
+                password,
+                udp_enabled,
+            } => f
+                .debug_struct("Mixed")
+                .field("username", username)
+                .field("password", &password.as_ref().map(|_| REDACTED))
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+            ServerProxyConfig::Naiveproxy {
+                users,
+                padding,
+                fallback,
+                udp_enabled,
+            } => f
+                .debug_struct("Naiveproxy")
+                .field("users", users)
+                .field("padding", padding)
+                .field("fallback", fallback)
+                .field("udp_enabled", udp_enabled)
+                .finish(),
+        }
+    }
+}
+
 impl std::fmt::Display for ServerProxyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -852,6 +1076,21 @@ mod tests {
             rules: NoneOrSome::None,
             dns: None,
         }
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_secrets() {
+        let config = ServerProxyConfig::TuicV5 {
+            uuid: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            password: "tuic_password".to_string(),
+            zero_rtt_handshake: false,
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(!debug.contains("tuic_password"));
     }
 
     fn create_test_server_config_socks() -> ServerConfig {

--- a/src/config/types/shadowsocks.rs
+++ b/src/config/types/shadowsocks.rs
@@ -5,7 +5,9 @@ use serde::Deserialize;
 
 use crate::shadowsocks::ShadowsocksCipher;
 
-#[derive(Debug, Clone)]
+const REDACTED: &str = "<redacted>";
+
+#[derive(Clone)]
 pub enum ShadowsocksConfig {
     Legacy {
         cipher: ShadowsocksCipher,
@@ -15,6 +17,24 @@ pub enum ShadowsocksConfig {
         cipher: ShadowsocksCipher,
         key_bytes: Box<[u8]>,
     },
+}
+
+impl std::fmt::Debug for ShadowsocksConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShadowsocksConfig::Legacy { cipher, .. } => f
+                .debug_struct("Legacy")
+                .field("cipher", cipher)
+                .field("password", &REDACTED)
+                .finish(),
+            ShadowsocksConfig::Aead2022 { cipher, key_bytes } => f
+                .debug_struct("Aead2022")
+                .field("cipher", cipher)
+                .field("key_bytes", &REDACTED)
+                .field("key_len", &key_bytes.len())
+                .finish(),
+        }
+    }
 }
 
 impl ShadowsocksConfig {

--- a/src/config/types/transport.rs
+++ b/src/config/types/transport.rs
@@ -1,6 +1,6 @@
 //! Transport-related configuration types.
 
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -8,6 +8,8 @@ use crate::address::{NetLocation, NetLocationPortRange};
 use crate::option_util::{NoneOrOne, NoneOrSome};
 
 use super::common::default_true;
+
+const REDACTED: &str = "<redacted>";
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -53,7 +55,7 @@ impl Default for TcpConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ServerQuicConfig {
     pub cert: String,
     pub key: String,
@@ -68,7 +70,20 @@ pub struct ServerQuicConfig {
     pub num_endpoints: usize,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+impl fmt::Debug for ServerQuicConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerQuicConfig")
+            .field("cert", &"<present>")
+            .field("key", &REDACTED)
+            .field("alpn_protocols", &self.alpn_protocols)
+            .field("client_ca_certs", &self.client_ca_certs)
+            .field("client_fingerprints", &self.client_fingerprints)
+            .field("num_endpoints", &self.num_endpoints)
+            .finish()
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ClientQuicConfig {
     #[serde(default = "default_true")]
     pub verify: bool,
@@ -82,6 +97,19 @@ pub struct ClientQuicConfig {
     pub key: Option<String>,
     #[serde(default)]
     pub cert: Option<String>,
+}
+
+impl fmt::Debug for ClientQuicConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClientQuicConfig")
+            .field("verify", &self.verify)
+            .field("server_fingerprints", &self.server_fingerprints)
+            .field("sni_hostname", &self.sni_hostname)
+            .field("alpn_protocols", &self.alpn_protocols)
+            .field("key", &self.key.as_ref().map(|_| REDACTED))
+            .field("cert", &self.cert.as_ref().map(|_| "<present>"))
+            .finish()
+    }
 }
 
 impl Default for ClientQuicConfig {

--- a/src/crypto/crypto_tls_stream.rs
+++ b/src/crypto/crypto_tls_stream.rs
@@ -255,7 +255,11 @@ where
                         }
                         Ok(_) => {
                             // Got data, process and wake to retry
-                            let _ = this.session.process_new_packets();
+                            if let Err(e) = this.session.process_new_packets() {
+                                // Try last-gasp write to send any pending TLS alerts (tokio-rustls pattern)
+                                let _ = this.drain_all_writes(cx);
+                                return Poll::Ready(Err(e));
+                            }
                             cx.waker().wake_by_ref();
                             Poll::Pending
                         }

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn shoes_start(
         runtime,
     };
 
-    let mut guard = TUN_SERVICE.get().unwrap().lock();
+    let mut guard = TUN_SERVICE.get_or_init(|| Mutex::new(None)).lock();
     *guard = Some(handle);
 
     1

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use log::debug;
+use subtle::ConstantTimeEq;
 use tokio::io::AsyncWriteExt;
 
 use crate::address::{Address, NetLocation, ResolvedLocation};
@@ -20,6 +21,11 @@ const PROXY_CONNECTION_HEADER_PREFIX: &str = "proxy-connection: ";
 
 fn create_http_auth_token(username: &str, password: &str) -> String {
     BASE64.encode(format!("{username}:{password}"))
+}
+
+#[inline]
+fn http_auth_token_matches(expected: &str, actual: &str) -> bool {
+    expected.as_bytes().ct_eq(actual.as_bytes()).unwrap_u8() == 1
 }
 
 #[derive(Debug)]
@@ -130,11 +136,11 @@ pub async fn setup_http_server_stream_inner(
                     && line[0..PROXY_AUTH_HEADER_PREFIX.len()].to_ascii_lowercase()
                         == PROXY_AUTH_HEADER_PREFIX
                 {
-                    if &line[PROXY_AUTH_HEADER_PREFIX.len()..] != auth_token.unwrap() {
-                        debug!(
-                            "Received incorrect HTTP CONNECT authentication: {}",
-                            &line[PROXY_AUTH_HEADER_PREFIX.len()..]
-                        );
+                    if !http_auth_token_matches(
+                        auth_token.unwrap(),
+                        &line[PROXY_AUTH_HEADER_PREFIX.len()..],
+                    ) {
+                        debug!("Received incorrect HTTP CONNECT authentication");
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
                             "Incorrect HTTP CONNECT authentication",
@@ -232,11 +238,11 @@ pub async fn setup_http_server_stream_inner(
                     && lowercase_line.starts_with(PROXY_AUTH_HEADER_PREFIX)
                 {
                     if need_auth {
-                        if &line[PROXY_AUTH_HEADER_PREFIX.len()..] != auth_token.unwrap() {
-                            debug!(
-                                "Received incorrect HTTP GET authentication: {}",
-                                &line[PROXY_AUTH_HEADER_PREFIX.len()..]
-                            );
+                        if !http_auth_token_matches(
+                            auth_token.unwrap(),
+                            &line[PROXY_AUTH_HEADER_PREFIX.len()..],
+                        ) {
+                            debug!("Received incorrect HTTP GET authentication");
                             return Err(std::io::Error::new(
                                 std::io::ErrorKind::InvalidInput,
                                 "Incorrect HTTP GET authentication",
@@ -447,5 +453,18 @@ impl TcpClientHandler for HttpTcpClientHandler {
             client_stream,
             early_data,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_token_match_requires_exact_token() {
+        let token = create_http_auth_token("user", "pass");
+
+        assert!(http_auth_token_matches(&token, &token));
+        assert!(!http_auth_token_matches(&token, "bad-token"));
     }
 }

--- a/src/hysteria2_server.rs
+++ b/src/hysteria2_server.rs
@@ -11,6 +11,7 @@ use log::{debug, error, warn};
 use rand::distr::Alphanumeric;
 use rand::{Rng, RngExt};
 use rustc_hash::FxHashMap;
+use subtle::ConstantTimeEq;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
@@ -20,6 +21,9 @@ use tokio_util::sync::CancellationToken;
 /// Maximum number of fragmented packets to track per session.
 /// Old entries are automatically evicted when this limit is reached.
 const MAX_FRAGMENT_CACHE_SIZE: usize = 256;
+
+/// Maximum UDP sessions per authenticated connection.
+const MAX_HY2_UDP_SESSIONS: usize = 4096;
 
 /// Authentication timeout - close connection if client doesn't authenticate within this time.
 /// Default is 3 seconds per sing-box reference implementation.
@@ -172,10 +176,8 @@ fn validate_auth_request<T>(req: http::Request<T>, password: &str) -> std::io::R
     let auth_str = auth_value
         .to_str()
         .map_err(|e| std::io::Error::other(format!("invalid auth header value: {e}")))?;
-    if auth_str != password {
-        return Err(std::io::Error::other(format!(
-            "incorrect auth password: {auth_str}"
-        )));
+    if password.as_bytes().ct_eq(auth_str.as_bytes()).unwrap_u8() == 0 {
+        return Err(std::io::Error::other("incorrect auth password"));
     }
 
     Ok(())
@@ -385,10 +387,11 @@ async fn run_udp_remote_to_local_loop(
         // session_id(4) + packet_id(2) + fragment id(1) + fragment count(1) + address length varint + address bytes
         let header_overhead = 4 + 2 + 1 + 1 + address_len_bytes.len() + address_bytes.len();
 
-        assert!(
-            max_datagram_size > header_overhead,
-            "max datagram size ({max_datagram_size}) is smaller than header overhead ({header_overhead})"
-        );
+        if max_datagram_size <= header_overhead {
+            return Err(std::io::Error::other(format!(
+                "max datagram size ({max_datagram_size}) is smaller than header overhead ({header_overhead})"
+            )));
+        }
 
         if header_overhead + payload_len <= max_datagram_size {
             let mut datagram = BytesMut::with_capacity(header_overhead + payload_len);
@@ -405,7 +408,11 @@ async fn run_udp_remote_to_local_loop(
                 .map_err(|e| std::io::Error::other(format!("Failed to send datagram: {e}")))?;
         } else {
             let available_payload = max_datagram_size - header_overhead;
-            let fragment_count = payload_len.div_ceil(available_payload) as u8;
+            let fragment_count = payload_len.div_ceil(available_payload);
+            if fragment_count > u8::MAX as usize {
+                return Err(std::io::Error::other("too many UDP fragments"));
+            }
+            let fragment_count = fragment_count as u8;
             for fragment_id in 0..fragment_count {
                 let start = (fragment_id as usize) * available_payload;
                 let end = std::cmp::min(start + available_payload, payload_len);
@@ -425,6 +432,101 @@ async fn run_udp_remote_to_local_loop(
             }
         }
     }
+}
+
+struct Hysteria2UdpDatagram {
+    session_id: u32,
+    packet_id: u16,
+    fragment_id: u8,
+    fragment_count: u8,
+    remote_location: NetLocation,
+    payload_fragment: Bytes,
+}
+
+fn decode_hysteria2_udp_datagram(data: Bytes) -> Option<Hysteria2UdpDatagram> {
+    // Per official hysteria reference (server.go:332-353), parse errors are ignored
+    // and we continue waiting for the next message. Only connection errors are fatal.
+    if data.len() < 9 {
+        debug!("Ignoring short datagram (len={})", data.len());
+        return None;
+    }
+    let session_id = u32::from_be_bytes(data[0..4].try_into().unwrap());
+    let packet_id = u16::from_be_bytes(data[4..6].try_into().unwrap());
+    let fragment_id = data[6];
+    let fragment_count = data[7];
+
+    let (address_len, next_index) = {
+        let first_byte = data[8];
+        let length_indicator = first_byte >> 6;
+        let mut value: u64 = (first_byte & 0b00111111) as u64;
+        let num_bytes = match length_indicator {
+            0 => 1,
+            1 => 2,
+            2 => 4,
+            3 => 8,
+            _ => {
+                // impossible since we only have 2 bits
+                unreachable!();
+            }
+        };
+        let mut next_index = 9;
+        if num_bytes > 1 {
+            let remaining_len = num_bytes - 1;
+            if data.len() < 9 + remaining_len {
+                debug!("Ignoring datagram with truncated address length varint");
+                return None;
+            }
+            let remaining = &data[9..9 + remaining_len];
+            for byte in remaining {
+                value <<= 8;
+                value |= *byte as u64;
+            }
+            next_index += remaining_len;
+        }
+        (value as usize, next_index)
+    };
+
+    if address_len == 0 {
+        debug!("Ignoring packet with empty address");
+        return None;
+    }
+
+    if address_len > 2048 {
+        debug!("Ignoring packet with address length {address_len}");
+        return None;
+    }
+
+    if data.len() < next_index + address_len {
+        debug!("Ignoring datagram with truncated address");
+        return None;
+    }
+    let address_bytes = &data[next_index..next_index + address_len];
+    let payload_fragment = data.slice(next_index + address_len..);
+
+    let addr_str = match str::from_utf8(address_bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("Invalid UTF-8 in address: {e}");
+            return None;
+        }
+    };
+
+    let remote_location = match NetLocation::from_str(addr_str, None) {
+        Ok(loc) => loc,
+        Err(e) => {
+            debug!("Failed to parse address '{addr_str}': {e}");
+            return None;
+        }
+    };
+
+    Some(Hysteria2UdpDatagram {
+        session_id,
+        packet_id,
+        fragment_id,
+        fragment_count,
+        remote_location,
+        payload_fragment,
+    })
 }
 
 async fn run_udp_local_to_remote_loop(
@@ -462,75 +564,22 @@ async fn run_udp_local_to_remote_loop(
             .await
             .map_err(|err| std::io::Error::other(format!("failed to read datagram: {err}")))?;
 
-        // Per official hysteria reference (server.go:332-353), parse errors are ignored
-        // and we continue waiting for the next message. Only connection errors are fatal.
-        if data.len() < 9 {
-            debug!("Ignoring short datagram (len={})", data.len());
+        let Some(Hysteria2UdpDatagram {
+            session_id,
+            packet_id,
+            fragment_id,
+            fragment_count,
+            remote_location,
+            payload_fragment,
+        }) = decode_hysteria2_udp_datagram(data)
+        else {
             continue;
-        }
-        let session_id = u32::from_be_bytes(data[0..4].try_into().unwrap());
-        let packet_id = u16::from_be_bytes(data[4..6].try_into().unwrap());
-        let fragment_id = data[6];
-        let fragment_count = data[7];
-
-        let (address_len, next_index) = {
-            let first_byte = data[8];
-            let length_indicator = first_byte >> 6;
-            let mut value: u64 = (first_byte & 0b00111111) as u64;
-            let num_bytes = match length_indicator {
-                0 => 1,
-                1 => 2,
-                2 => 4,
-                3 => 8,
-                _ => {
-                    // impossible since we only have 2 bits
-                    unreachable!();
-                }
-            };
-            let mut next_index = 9;
-            if num_bytes > 1 {
-                let remaining = &data[9..9 + (num_bytes - 1)];
-                for byte in remaining {
-                    value <<= 8;
-                    value |= *byte as u64;
-                }
-                next_index += num_bytes - 1;
-            }
-            (value as usize, next_index)
         };
 
-        if address_len == 0 {
-            debug!("Ignoring packet with empty address");
+        if !sessions.contains_key(&session_id) && sessions.len() >= MAX_HY2_UDP_SESSIONS {
+            warn!("Ignoring UDP session {session_id}: session cap reached");
             continue;
         }
-
-        if address_len > 2048 {
-            debug!("Ignoring packet with address length {address_len}");
-            continue;
-        }
-
-        if data.len() < next_index + address_len {
-            debug!("Ignoring datagram with truncated address");
-            continue;
-        }
-        let address_bytes = &data[next_index..next_index + address_len];
-        let payload_fragment = data.slice(next_index + address_len..);
-
-        let addr_str = match str::from_utf8(address_bytes) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!("Invalid UTF-8 in address: {e}");
-                continue;
-            }
-        };
-
-        let remote_location = match NetLocation::from_str(addr_str, None) {
-            Ok(loc) => loc,
-            Err(e) => {
-                debug!("Failed to parse address '{addr_str}': {e}");
-                continue;
-            }
-        };
 
         let mut session_entry = sessions.entry(session_id);
         let session = match session_entry {
@@ -612,6 +661,9 @@ async fn run_udp_local_to_remote_loop(
 
         let (complete_payload, remote_location) = if fragment_count == 0 {
             error!("Ignoring empty UDP fragment for session {session_id}");
+            continue;
+        } else if fragment_id >= fragment_count {
+            error!("Invalid fragment id {fragment_id} >= total {fragment_count}");
             continue;
         } else if fragment_count == 1 {
             (payload_fragment, remote_location)
@@ -1051,4 +1103,32 @@ pub async fn start_hysteria2_server(
     }
 
     Ok(join_handles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_udp_datagram_ignores_truncated_varint_length() {
+        let mut data = vec![0u8; 9];
+        data[8] = 0b0100_0000;
+
+        assert!(decode_hysteria2_udp_datagram(Bytes::from(data)).is_none());
+    }
+
+    #[test]
+    fn validate_auth_request_does_not_echo_wrong_password() {
+        let req = http::Request::builder()
+            .uri("https://hysteria/auth")
+            .method("POST")
+            .header("hysteria-auth", "attacker-password")
+            .body(())
+            .unwrap();
+
+        let err = validate_auth_request(req, "correct-password").unwrap_err();
+        let message = err.to_string();
+        assert_eq!(message, "incorrect auth password");
+        assert!(!message.contains("attacker-password"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ mod socket_util;
 mod socks5_udp_relay;
 mod socks_handler;
 mod stream_reader;
+mod stream_worker_pool;
 mod sync_adapter;
 mod tcp;
 mod thread_util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod socket_util;
 mod socks5_udp_relay;
 mod socks_handler;
 mod stream_reader;
+mod stream_worker_pool;
 mod sync_adapter;
 mod tcp;
 mod thread_util;
@@ -62,7 +63,7 @@ use std::path::Path;
 
 use aws_lc_rs::rand::{SecureRandom, SystemRandom};
 use base64::engine::{Engine as _, general_purpose::STANDARD};
-use log::debug;
+use log::{debug, error, warn};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tcp_server::start_servers;
 use tokio::runtime::Builder;
@@ -78,26 +79,23 @@ struct ConfigChanged;
 
 fn start_notify_thread(
     config_paths: Vec<String>,
-) -> (RecommendedWatcher, UnboundedReceiver<ConfigChanged>) {
+) -> notify::Result<(RecommendedWatcher, UnboundedReceiver<ConfigChanged>)> {
     let (tx, rx) = unbounded_channel();
 
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| match res {
         Ok(event) => {
             if matches!(event.kind, EventKind::Modify(..)) {
-                tx.send(ConfigChanged {}).unwrap();
+                let _ = tx.send(ConfigChanged {});
             }
         }
         Err(e) => println!("watch error: {e:?}"),
-    })
-    .unwrap();
+    })?;
 
     for config_path in config_paths {
-        watcher
-            .watch(Path::new(&config_path), RecursiveMode::NonRecursive)
-            .unwrap();
+        watcher.watch(Path::new(&config_path), RecursiveMode::NonRecursive)?;
     }
 
-    (watcher, rx)
+    Ok((watcher, rx))
 }
 
 fn print_usage_and_exit(arg0: String) {
@@ -317,8 +315,13 @@ fn main() {
         let mut reload_state = if no_reload {
             None
         } else {
-            let (watcher, rx) = start_notify_thread(args.clone());
-            Some((watcher, rx))
+            match start_notify_thread(args.clone()) {
+                Ok((watcher, rx)) => Some((watcher, rx)),
+                Err(e) => {
+                    eprintln!("Failed to start config watcher: {e}");
+                    return;
+                }
+            }
         };
 
         loop {
@@ -341,7 +344,7 @@ fn main() {
             };
 
             if load_file_count > 0 {
-                    println!("Loaded {load_file_count} certs/keys from files");
+                println!("Loaded {load_file_count} certs/keys from files");
             }
 
             for config in configs.iter() {
@@ -387,6 +390,7 @@ fn main() {
 
             println!("\nStarting {} server(s)..", server_configs.len());
 
+            let mut start_failed = false;
             for server_config in server_configs {
                 // Get the resolver for this server from the registry
                 let dns_ref = match &server_config {
@@ -395,12 +399,48 @@ fn main() {
                     _ => None,
                 };
                 let resolver = dns_registry.get_for_server(dns_ref);
-                join_handles.extend(start_servers(server_config, resolver).await.unwrap());
+                match start_servers(server_config, resolver).await {
+                    Ok(handles) => join_handles.extend(handles),
+                    Err(e) => {
+                        error!("Failed to start server: {e}");
+                        start_failed = true;
+                        break;
+                    }
+                }
+            }
+
+            if start_failed {
+                for join_handle in join_handles {
+                    join_handle.abort();
+                }
+
+                match reload_state.as_mut() {
+                    Some((_watcher, rx)) => {
+                        warn!("Waiting for config change before retrying server start");
+                        match rx.recv().await {
+                            Some(_) => {
+                                while rx.try_recv().is_ok() {}
+                                continue;
+                            }
+                            None => {
+                                warn!("Config watcher exited");
+                                break;
+                            }
+                        }
+                    }
+                    None => return,
+                }
             }
 
             match reload_state.as_mut() {
                 Some((_watcher, rx)) => {
-                    rx.recv().await.unwrap();
+                    match rx.recv().await {
+                        Some(_) => {}
+                        None => {
+                            warn!("Config watcher exited");
+                            break;
+                        }
+                    }
 
                     println!("Configs changed, restarting servers in 3 seconds..");
 

--- a/src/reality/reality_client_connection.rs
+++ b/src/reality/reality_client_connection.rs
@@ -4,13 +4,15 @@ use std::io::{self, Read, Write};
 
 use aws_lc_rs::{agreement, digest};
 use rand::Rng;
+use zeroize::{Zeroize, Zeroizing};
 
 use super::common::{
     ALERT_DESC_CLOSE_NOTIFY, ALERT_LEVEL_WARNING, CIPHERTEXT_READ_BUF_CAPACITY, CONTENT_TYPE_ALERT,
     CONTENT_TYPE_APPLICATION_DATA, CONTENT_TYPE_CHANGE_CIPHER_SPEC, CONTENT_TYPE_HANDSHAKE,
     HANDSHAKE_TYPE_CERTIFICATE, HANDSHAKE_TYPE_CERTIFICATE_VERIFY,
-    HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS, HANDSHAKE_TYPE_FINISHED, OUTGOING_BUFFER_LIMIT,
-    PLAINTEXT_READ_BUF_CAPACITY, TLS_MAX_RECORD_SIZE, TLS_RECORD_HEADER_SIZE,
+    HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS, HANDSHAKE_TYPE_FINISHED, MAX_TLS_PLAINTEXT_LEN,
+    OUTGOING_BUFFER_LIMIT, PLAINTEXT_READ_BUF_CAPACITY, TLS_MAX_RECORD_SIZE,
+    TLS_RECORD_HEADER_SIZE,
 };
 use super::reality_aead::{AeadKey, decrypt_handshake_message};
 use super::reality_auth::{derive_auth_key, encrypt_session_id, perform_ecdh};
@@ -72,6 +74,25 @@ enum HandshakeState {
     },
     /// Handshake complete, ready for application data
     Complete,
+}
+
+impl Drop for HandshakeState {
+    fn drop(&mut self) {
+        match self {
+            HandshakeState::AwaitingServerHello {
+                client_private_key,
+                auth_key,
+                ..
+            } => {
+                client_private_key.zeroize();
+                auth_key.zeroize();
+            }
+            HandshakeState::ProcessingHandshake { auth_key, .. } => {
+                auth_key.zeroize();
+            }
+            HandshakeState::Complete => {}
+        }
+    }
 }
 
 /// REALITY client-side connection implementing rustls-compatible API
@@ -141,11 +162,11 @@ impl RealityClientConnection {
     fn generate_client_hello(&mut self) -> io::Result<()> {
         let mut rng = rand::rng();
 
-        let mut our_private_bytes = [0u8; 32];
-        rng.fill_bytes(&mut our_private_bytes);
+        let mut our_private_bytes = Zeroizing::new([0u8; 32]);
+        rng.fill_bytes(&mut *our_private_bytes);
 
         let our_private_key =
-            agreement::PrivateKey::from_private_key(&agreement::X25519, &our_private_bytes)
+            agreement::PrivateKey::from_private_key(&agreement::X25519, &*our_private_bytes)
                 .map_err(|_| io::Error::other("Failed to create X25519 key"))?;
         let our_public_key_bytes = our_private_key
             .compute_public_key()
@@ -155,12 +176,17 @@ impl RealityClientConnection {
         rng.fill_bytes(&mut client_random);
 
         // Perform ECDH with server's public key to derive auth key
-        let shared_secret = perform_ecdh(&our_private_bytes, &self.config.public_key)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let mut shared_secret = Zeroizing::new(
+            perform_ecdh(&our_private_bytes, &self.config.public_key)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?,
+        );
 
         // Use slice directly from client_random to avoid copying
-        let auth_key = derive_auth_key(&shared_secret, &client_random[0..20], b"REALITY")
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let auth_key = Zeroizing::new(
+            derive_auth_key(&shared_secret, &client_random[0..20], b"REALITY")
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?,
+        );
+        shared_secret.zeroize();
 
         // Create session ID with REALITY metadata
         let timestamp = std::time::SystemTime::now()
@@ -207,24 +233,14 @@ impl RealityClientConnection {
         // SessionId is at offset 39 in ClientHello handshake
         client_hello[39..71].fill(0);
 
-        log::debug!("REALITY CLIENT: Encrypting SessionId");
-        log::debug!("  auth_key={:02x?}", &auth_key);
-        log::debug!("  nonce={:02x?}", nonce);
-        log::debug!("  plaintext={:02x?}", &session_id_plaintext);
         log::debug!(
-            "  aad_len={} (ClientHello with zero SessionId)",
+            "REALITY CLIENT: Encrypting SessionId with aad_len={} (ClientHello with zero SessionId)",
             client_hello.len()
         );
-        log::debug!("  aad[0..4]={:02x?}", &client_hello[0..4]);
 
         let encrypted_session_id =
             encrypt_session_id(&session_id_plaintext, &auth_key, nonce, &client_hello)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-        log::debug!(
-            "REALITY CLIENT: Encrypted SessionId={:02x?}",
-            &encrypted_session_id
-        );
 
         // Restore the encrypted SessionId before writing or storing ClientHello.
         // REALITY transcripts use the wire ClientHello, not the zeroed AAD form.
@@ -238,8 +254,8 @@ impl RealityClientConnection {
         // At this point client_hello contains the encrypted SessionId.
         self.handshake_state = HandshakeState::AwaitingServerHello {
             client_hello_bytes: client_hello, // Save the actual ClientHello bytes
-            client_private_key: our_private_bytes,
-            auth_key, // Save auth_key for HMAC certificate verification
+            client_private_key: *our_private_bytes,
+            auth_key: *auth_key, // Save auth_key for HMAC certificate verification
         };
 
         log::debug!(
@@ -330,7 +346,10 @@ impl RealityClientConnection {
             auth_key,
         } = &self.handshake_state
         else {
-            unreachable!()
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "process_server_hello called in wrong state",
+            ));
         };
 
         if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE {
@@ -406,7 +425,7 @@ impl RealityClientConnection {
             agreement::PrivateKey::from_private_key(&agreement::X25519, client_private_key)
                 .map_err(|_| io::Error::other("Failed to create private key"))?;
 
-        let mut tls_shared_secret = [0u8; 32];
+        let mut tls_shared_secret = Zeroizing::new([0u8; 32]);
         agreement::agree(
             &my_private_key,
             peer_public_key,
@@ -419,7 +438,7 @@ impl RealityClientConnection {
 
         let hs_keys = derive_handshake_keys(
             cipher_suite,
-            &tls_shared_secret,
+            &*tls_shared_secret,
             &client_hello_hash_vec,
             &server_hello_hash_vec,
         )?;
@@ -470,66 +489,61 @@ impl RealityClientConnection {
             cert_verify_offset,
         } = &self.handshake_state
         else {
-            unreachable!()
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "process_encrypted_handshake called in wrong state",
+            ));
         };
 
         let (server_hs_key, server_hs_iv) =
             derive_traffic_keys(server_handshake_traffic_secret, *cipher_suite)?;
 
-        if *handshake_seq == 0 {
-            log::debug!(
-                "REALITY CLIENT: Server HS key={:02x?}, iv={:02x?}",
-                &server_hs_key[..16],
-                &server_hs_iv
-            );
-        }
+        let (record_len, total_record_len) =
+            loop {
+                if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE {
+                    return Ok(false);
+                }
 
-        if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE {
-            return Ok(false);
-        }
+                let record_type = self.ciphertext_read_buf[0];
+                let tls_version = self.ciphertext_read_buf.get_u16_be(1).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Buffer too short")
+                })?;
+                let record_len =
+                    self.ciphertext_read_buf.get_u16_be(3).ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "Buffer too short")
+                    })? as usize;
 
-        let record_type = self.ciphertext_read_buf[0];
-        let tls_version = self
-            .ciphertext_read_buf
-            .get_u16_be(1)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Buffer too short"))?;
-        let record_len = self
-            .ciphertext_read_buf
-            .get_u16_be(3)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Buffer too short"))?
-            as usize;
+                log::debug!(
+                    "REALITY CLIENT: TLS record header: type=0x{:02x}, version=0x{:04x}, len={}",
+                    record_type,
+                    tls_version,
+                    record_len
+                );
 
-        log::debug!(
-            "REALITY CLIENT: TLS record header: type=0x{:02x}, version=0x{:04x}, len={}",
-            record_type,
-            tls_version,
-            record_len
-        );
+                let total_record_len = TLS_RECORD_HEADER_SIZE + record_len;
+                if self.ciphertext_read_buf.len() < total_record_len {
+                    return Ok(false);
+                }
 
-        let total_record_len = TLS_RECORD_HEADER_SIZE + record_len;
-        if self.ciphertext_read_buf.len() < total_record_len {
-            return Ok(false);
-        }
+                // Skip ChangeCipherSpec (dummy in TLS 1.3)
+                if record_type == CONTENT_TYPE_CHANGE_CIPHER_SPEC {
+                    log::debug!(
+                        "REALITY CLIENT: Skipping ChangeCipherSpec record ({} bytes)",
+                        record_len
+                    );
+                    self.ciphertext_read_buf.consume(total_record_len);
+                    continue;
+                }
 
-        // Skip ChangeCipherSpec (dummy in TLS 1.3)
-        if record_type == CONTENT_TYPE_CHANGE_CIPHER_SPEC {
-            log::debug!(
-                "REALITY CLIENT: Skipping ChangeCipherSpec record ({} bytes)",
-                record_len
-            );
-            self.ciphertext_read_buf.consume(total_record_len);
-            return self.process_encrypted_handshake();
-        }
+                if record_type != CONTENT_TYPE_APPLICATION_DATA {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Expected Application Data record, got 0x{record_type:02x}"),
+                    ));
+                }
 
-        if record_type != CONTENT_TYPE_APPLICATION_DATA {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "Expected Application Data record, got 0x{:02x}",
-                    record_type
-                ),
-            ));
-        }
+                break (record_len, total_record_len);
+            };
 
         // NOW we're committed to processing - clone/copy fields we need to modify
         let client_hs_secret = client_handshake_traffic_secret.clone();
@@ -538,7 +552,7 @@ impl RealityClientConnection {
         let transcript_bytes = handshake_transcript_bytes.clone();
         let mut accumulated_plaintext = accumulated_plaintext.clone();
         let cipher_suite = *cipher_suite;
-        let auth_key = *auth_key;
+        let auth_key = Zeroizing::new(*auth_key);
         let mut handshake_seq = *handshake_seq;
         let mut messages_found = *messages_found;
         let mut certificate_verified = *certificate_verified;
@@ -576,6 +590,10 @@ impl RealityClientConnection {
 
         // Track where new plaintext starts in accumulated buffer
         let prev_accumulated_len = accumulated_plaintext.len();
+        const MAX_ACCUMULATED_PLAINTEXT: usize = 4 * MAX_TLS_PLAINTEXT_LEN;
+        if prev_accumulated_len.saturating_add(plaintext.len()) > MAX_ACCUMULATED_PLAINTEXT {
+            return Err(io::Error::other("REALITY handshake too large"));
+        }
         accumulated_plaintext.extend_from_slice(&plaintext);
 
         // Parse newly added messages from the plaintext we just added
@@ -642,7 +660,7 @@ impl RealityClientConnection {
                 master_secret,
                 cipher_suite,
                 handshake_transcript_bytes: transcript_bytes,
-                auth_key,
+                auth_key: *auth_key,
                 handshake_seq,
                 accumulated_plaintext,
                 messages_found,
@@ -718,10 +736,6 @@ impl RealityClientConnection {
 
         let client_verify_data =
             compute_finished_verify_data(cipher_suite, &client_hs_secret, &handshake_hash_vec)?;
-        log::debug!(
-            "REALITY CLIENT: Client verify data: {:02x?}",
-            client_verify_data
-        );
         let client_finished = construct_finished(&client_verify_data)?;
 
         let (client_hs_key, client_hs_iv) = derive_traffic_keys(&client_hs_secret, cipher_suite)?;
@@ -771,7 +785,12 @@ impl RealityClientConnection {
     fn process_application_data(&mut self) -> io::Result<()> {
         let (app_read_key, app_read_iv) = match (&self.app_read_key, &self.app_read_iv) {
             (Some(key), Some(iv)) => (key, iv),
-            _ => unreachable!(), // Wrong state
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Application keys not available",
+                ));
+            }
         };
 
         while self.ciphertext_read_buf.len() >= TLS_RECORD_HEADER_SIZE {
@@ -797,7 +816,10 @@ impl RealityClientConnection {
             match content_type {
                 CONTENT_TYPE_APPLICATION_DATA => {
                     // Compact plaintext buffer if needed before extending
-                    self.plaintext_read_buf.maybe_compact(4096);
+                    self.plaintext_read_buf.maybe_compact(0);
+                    if self.plaintext_read_buf.remaining_capacity() < plaintext.len() {
+                        return Err(io::Error::other("plaintext buffer full"));
+                    }
                     self.plaintext_read_buf.extend_from_slice(plaintext);
                 }
                 CONTENT_TYPE_ALERT => {
@@ -831,12 +853,12 @@ impl RealityClientConnection {
                         }
                     }
                 }
-                // CONTENT_TYPE_HANDSHAKE is invalid after handshake complete
-                // strip_content_type() validates and returns error for invalid types
-                _ => unreachable!(
-                    "strip_content_type validates content type; unexpected: 0x{:02x}",
-                    content_type
-                ),
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Unexpected TLS content type: 0x{content_type:02x}"),
+                    ));
+                }
             }
 
             // Consume the processed record from the buffer (after plaintext borrow ends)

--- a/src/reality/reality_server_connection.rs
+++ b/src/reality/reality_server_connection.rs
@@ -7,6 +7,7 @@ use aws_lc_rs::{agreement, digest};
 use rand::Rng;
 use std::io::{self, Read, Write};
 use subtle::ConstantTimeEq;
+use zeroize::{Zeroize, Zeroizing};
 
 use super::common::{
     ALERT_DESC_CLOSE_NOTIFY, ALERT_LEVEL_WARNING, CIPHERTEXT_READ_BUF_CAPACITY, CONTENT_TYPE_ALERT,
@@ -56,6 +57,12 @@ pub struct RealityServerConfig {
     pub cipher_suites: Vec<CipherSuite>,
 }
 
+impl Drop for RealityServerConfig {
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+    }
+}
+
 /// Handshake state machine for REALITY server
 enum HandshakeState {
     /// Initial state, waiting for ClientHello
@@ -87,6 +94,12 @@ pub struct ClientHelloInfo {
     pub cipher_suite: CipherSuite,
     /// Raw ClientHello handshake bytes (for transcript hash)
     pub client_hello_handshake: Vec<u8>,
+}
+
+impl Drop for ClientHelloInfo {
+    fn drop(&mut self) {
+        self.auth_key.zeroize();
+    }
 }
 
 /// REALITY server-side connection implementing rustls-compatible API
@@ -304,12 +317,15 @@ impl RealityServerConnection {
         );
 
         // Perform ECDH to derive auth key
-        let shared_secret = perform_ecdh(&self.config.private_key, &client_public_key)
+        let mut shared_secret = perform_ecdh(&self.config.private_key, &client_public_key)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         let salt = &client_random[0..20];
-        let auth_key = derive_auth_key(&shared_secret, salt, b"REALITY")
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let auth_key = Zeroizing::new(
+            derive_auth_key(&shared_secret, salt, b"REALITY")
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?,
+        );
+        shared_secret.zeroize();
 
         // Validate session ID (contains encrypted metadata)
         if session_id.len() != 32 {
@@ -339,7 +355,7 @@ impl RealityServerConnection {
         .map_err(|e| {
             io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                format!("Session ID decrypt failed: {:?}", e),
+                format!("REALITY authentication failed: {e}"),
             )
         })?;
 
@@ -355,7 +371,6 @@ impl RealityServerConnection {
 
         log::debug!("REALITY: Client version: {:?}", client_version);
         log::debug!("REALITY: Client timestamp: {}", client_timestamp);
-        log::debug!("REALITY: Client short_id: {:02x?}", client_short_id);
 
         // Validate short ID using constant-time comparison
         let mut client_short_id_arr = [0u8; 8];
@@ -365,13 +380,11 @@ impl RealityServerConnection {
         });
 
         if !short_id_ok {
-            log::warn!(
-                "REALITY: Client short_id {:02x?} not in configured list",
-                client_short_id
-            );
+            log::warn!("TLS handshake failed, forwarding to dest");
+            log::debug!("REALITY: Client short_id not in configured list");
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                format!("Invalid short_id: {:02x?}", client_short_id),
+                "Invalid REALITY authentication metadata",
             ));
         }
 
@@ -386,19 +399,11 @@ impl RealityServerConnection {
             let max_diff_secs = max_diff_ms / 1000;
 
             if time_diff_secs > max_diff_secs {
-                log::warn!(
-                    "REALITY: Client timestamp {} differs from server {} by {} seconds (max: {} seconds)",
-                    client_timestamp,
-                    now,
-                    time_diff_secs,
-                    max_diff_secs
-                );
+                log::warn!("TLS handshake failed, forwarding to dest");
+                log::debug!("REALITY: Client timestamp outside accepted window");
                 return Err(io::Error::new(
                     io::ErrorKind::PermissionDenied,
-                    format!(
-                        "Timestamp difference {} seconds exceeds maximum {} seconds",
-                        time_diff_secs, max_diff_secs
-                    ),
+                    "REALITY timestamp outside accepted window",
                 ));
             }
         }
@@ -407,17 +412,11 @@ impl RealityServerConnection {
         if let Some(min_ver) = &self.config.min_client_version
             && client_version < &min_ver[..]
         {
-            log::warn!(
-                "REALITY: Client version {:?} is below minimum {:?}",
-                client_version,
-                min_ver
-            );
+            log::warn!("TLS handshake failed, forwarding to dest");
+            log::debug!("REALITY: Client version below configured minimum");
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                format!(
-                    "Client version {:?} is below minimum {:?}",
-                    client_version, min_ver
-                ),
+                "REALITY client version outside accepted range",
             ));
         }
 
@@ -425,26 +424,15 @@ impl RealityServerConnection {
         if let Some(max_ver) = &self.config.max_client_version
             && client_version > &max_ver[..]
         {
-            log::warn!(
-                "REALITY: Client version {:?} is above maximum {:?}",
-                client_version,
-                max_ver
-            );
+            log::warn!("TLS handshake failed, forwarding to dest");
+            log::debug!("REALITY: Client version above configured maximum");
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                format!(
-                    "Client version {:?} is above maximum {:?}",
-                    client_version, max_ver
-                ),
+                "REALITY client version outside accepted range",
             ));
         }
 
-        log::debug!(
-            "REALITY: Client authentication successful - short_id: {:02x?}, version: {:?}, timestamp: {}",
-            client_short_id,
-            client_version,
-            client_timestamp
-        );
+        log::debug!("REALITY: Client authentication successful");
 
         // Negotiate cipher suite with client
         let client_cipher_suites = extract_client_cipher_suites(client_hello)?;
@@ -471,7 +459,7 @@ impl RealityServerConnection {
             info: ClientHelloInfo {
                 session_id: session_id.to_vec(),
                 client_public_key,
-                auth_key,
+                auth_key: *auth_key,
                 cipher_suite,
                 client_hello_handshake: client_hello_handshake.to_vec(),
             },
@@ -486,18 +474,21 @@ impl RealityServerConnection {
         let HandshakeState::ClientHelloValidated { info } =
             std::mem::replace(&mut self.handshake_state, HandshakeState::Initial)
         else {
-            unreachable!()
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "build_server_response called in wrong state",
+            ));
         };
 
         let cipher_suite = info.cipher_suite;
 
         // Generate our server X25519 keypair
         let mut rng = rand::rng();
-        let mut our_private_bytes = [0u8; 32];
-        rng.fill_bytes(&mut our_private_bytes);
+        let mut our_private_bytes = Zeroizing::new([0u8; 32]);
+        rng.fill_bytes(&mut *our_private_bytes);
 
         let our_private_key =
-            agreement::PrivateKey::from_private_key(&agreement::X25519, &our_private_bytes)
+            agreement::PrivateKey::from_private_key(&agreement::X25519, &*our_private_bytes)
                 .map_err(|_| io::Error::other("Failed to create X25519 key"))?;
         let our_public_key_bytes = our_private_key
             .compute_public_key()
@@ -532,7 +523,7 @@ impl RealityServerConnection {
         // Perform ECDH for TLS 1.3 key derivation
         let peer_public_key =
             agreement::UnparsedPublicKey::new(&agreement::X25519, &info.client_public_key);
-        let mut tls_shared_secret = [0u8; 32];
+        let mut tls_shared_secret = Zeroizing::new([0u8; 32]);
         agreement::agree(
             &our_private_key,
             peer_public_key,
@@ -546,7 +537,7 @@ impl RealityServerConnection {
         // Derive TLS 1.3 keys
         let hs_keys = derive_handshake_keys(
             cipher_suite,
-            &tls_shared_secret,
+            &*tls_shared_secret,
             client_hello_hash.as_ref(),
             server_hello_hash.as_ref(),
         )?;
@@ -767,14 +758,30 @@ impl RealityServerConnection {
         // NOW we're committed to processing - take ownership of handshake state
         // This avoids cloning Vec<u8> fields
         let old_state = std::mem::replace(&mut self.handshake_state, HandshakeState::Complete);
-        let HandshakeState::ServerHelloSent {
+        let (
             client_handshake_traffic_secret,
             master_secret,
             cipher_suite,
             handshake_hash_with_server_finished,
-        } = old_state
-        else {
-            unreachable!()
+        ) = match old_state {
+            HandshakeState::ServerHelloSent {
+                client_handshake_traffic_secret,
+                master_secret,
+                cipher_suite,
+                handshake_hash_with_server_finished,
+            } => (
+                client_handshake_traffic_secret,
+                master_secret,
+                cipher_suite,
+                handshake_hash_with_server_finished,
+            ),
+            other => {
+                self.handshake_state = other;
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "process_client_finished called in wrong state",
+                ));
+            }
         };
 
         // Extract the encrypted Finished record (copy to Vec for decryption)
@@ -876,7 +883,12 @@ impl RealityServerConnection {
         // Check if we have application keys
         let (app_read_key, app_read_iv) = match (&self.app_read_key, &self.app_read_iv) {
             (Some(key), Some(iv)) => (key, iv),
-            _ => unreachable!(), // Wrong state
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Application keys not available",
+                ));
+            }
         };
 
         // Process all complete TLS records in the buffer
@@ -905,7 +917,10 @@ impl RealityServerConnection {
             match content_type {
                 CONTENT_TYPE_APPLICATION_DATA => {
                     // Compact plaintext buffer if needed before extending
-                    self.plaintext_read_buf.maybe_compact(4096);
+                    self.plaintext_read_buf.maybe_compact(0);
+                    if self.plaintext_read_buf.remaining_capacity() < plaintext.len() {
+                        return Err(io::Error::other("plaintext buffer full"));
+                    }
                     self.plaintext_read_buf.extend_from_slice(plaintext);
                 }
                 CONTENT_TYPE_ALERT => {
@@ -936,12 +951,12 @@ impl RealityServerConnection {
                         }
                     }
                 }
-                // CONTENT_TYPE_HANDSHAKE is invalid after handshake complete
-                // strip_content_type() validates and returns error for invalid types
-                _ => unreachable!(
-                    "strip_content_type validates content type; unexpected: 0x{:02x}",
-                    content_type
-                ),
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Unexpected TLS content type: 0x{content_type:02x}"),
+                    ));
+                }
             }
 
             // Consume the processed record from the buffer (after plaintext borrow ends)

--- a/src/reality/reality_tls13_messages.rs
+++ b/src/reality/reality_tls13_messages.rs
@@ -259,6 +259,52 @@ pub fn construct_finished(verify_data: &[u8]) -> Result<Vec<u8>> {
 /// Default ALPN protocols for REALITY client (matches browser fingerprints)
 pub const DEFAULT_ALPN_PROTOCOLS: &[&str] = &["h2", "http/1.1"];
 
+const CHROME_TLS12_COMPAT_CIPHER_SUITES: &[u16] = &[
+    0xc02b, // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    0xc02f, // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    0xc02c, // TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    0xc030, // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    0xcca9, // TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+    0xcca8, // TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+    0xc013, // TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+    0xc014, // TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+    0x009c, // TLS_RSA_WITH_AES_128_GCM_SHA256
+    0x009d, // TLS_RSA_WITH_AES_256_GCM_SHA384
+    0x002f, // TLS_RSA_WITH_AES_128_CBC_SHA
+    0x0035, // TLS_RSA_WITH_AES_256_CBC_SHA
+];
+
+const GREASE_VALUES: &[u16] = &[
+    0x0a0a, 0x1a1a, 0x2a2a, 0x3a3a, 0x4a4a, 0x5a5a, 0x6a6a, 0x7a7a, 0x8a8a, 0x9a9a, 0xaaaa, 0xbaba,
+    0xcaca, 0xdada, 0xeaea, 0xfafa,
+];
+
+fn grease_value(client_random: &[u8; 32], domain_separator: usize) -> u16 {
+    GREASE_VALUES[(client_random[0] as usize + domain_separator) % GREASE_VALUES.len()]
+}
+
+#[cfg(test)]
+fn is_grease_value(value: u16) -> bool {
+    GREASE_VALUES.contains(&value)
+}
+
+fn chrome_like_cipher_suites(client_random: &[u8; 32], configured_suites: &[u16]) -> Vec<u16> {
+    let mut suites =
+        Vec::with_capacity(1 + configured_suites.len() + CHROME_TLS12_COMPAT_CIPHER_SUITES.len());
+    suites.push(grease_value(client_random, 0));
+
+    for &suite in configured_suites
+        .iter()
+        .chain(CHROME_TLS12_COMPAT_CIPHER_SUITES.iter())
+    {
+        if !suites.contains(&suite) {
+            suites.push(suite);
+        }
+    }
+
+    suites
+}
+
 /// Construct TLS 1.3 ClientHello message
 ///
 /// Returns handshake message bytes (without record header)
@@ -268,7 +314,7 @@ pub const DEFAULT_ALPN_PROTOCOLS: &[&str] = &["h2", "http/1.1"];
 /// * `session_id` - 32 bytes session ID
 /// * `client_public_key` - X25519 public key bytes
 /// * `server_name` - SNI hostname
-/// * `cipher_suites` - Cipher suite IDs to offer (e.g., &[0x1301, 0x1302, 0x1303])
+/// * `cipher_suites` - TLS 1.3 cipher suite IDs to include before browser-style fallback suites
 /// * `alpn_protocols` - ALPN protocols to offer (e.g., &["h2", "http/1.1"])
 pub fn construct_client_hello(
     client_random: &[u8; 32],
@@ -279,6 +325,10 @@ pub fn construct_client_hello(
     alpn_protocols: &[&str],
 ) -> Result<Vec<u8>> {
     let mut hello = Vec::with_capacity(512);
+    let offered_cipher_suites = chrome_like_cipher_suites(client_random, cipher_suites);
+    let cipher_suite_grease = offered_cipher_suites[0];
+    let supported_group_grease = grease_value(client_random, 1);
+    let extension_grease = grease_value(client_random, 2);
 
     // Handshake message type: ClientHello (0x01)
     hello.push(0x01);
@@ -298,9 +348,9 @@ pub fn construct_client_hello(
     hello.extend_from_slice(session_id);
 
     // Cipher suites
-    let cipher_suites_len = (cipher_suites.len() * 2) as u16;
+    let cipher_suites_len = (offered_cipher_suites.len() * 2) as u16;
     hello.extend_from_slice(&cipher_suites_len.to_be_bytes());
-    for &suite in cipher_suites {
+    for &suite in &offered_cipher_suites {
         hello.extend_from_slice(&suite.to_be_bytes());
     }
 
@@ -312,6 +362,13 @@ pub fn construct_client_hello(
     hello.extend_from_slice(&[0u8; 2]); // Placeholder for extensions length
 
     let mut extensions = Vec::new();
+
+    // GREASE extension. The empty body is ignored by compliant peers and makes the
+    // default ClientHello less trivially distinguishable from modern browsers.
+    {
+        extensions.extend_from_slice(&extension_grease.to_be_bytes());
+        extensions.extend_from_slice(&[0x00, 0x00]);
+    }
 
     // server_name extension (type 0)
     {
@@ -330,26 +387,35 @@ pub fn construct_client_hello(
     // supported_versions extension (type 43)
     {
         extensions.extend_from_slice(&[0x00, 0x2b]); // Extension type: supported_versions
-        extensions.extend_from_slice(&[0x00, 0x03]); // Extension length: 3
-        extensions.push(0x02); // Supported versions length: 2
+        extensions.extend_from_slice(&[0x00, 0x07]); // Extension length: 7
+        extensions.push(0x06); // Supported versions length: 6
+        extensions.extend_from_slice(&cipher_suite_grease.to_be_bytes());
         extensions.extend_from_slice(&[0x03, 0x04]); // TLS 1.3
+        extensions.extend_from_slice(&[0x03, 0x03]); // TLS 1.2
     }
 
     // supported_groups extension (type 10)
     {
         extensions.extend_from_slice(&[0x00, 0x0a]); // Extension type: supported_groups
-        extensions.extend_from_slice(&[0x00, 0x04]); // Extension length: 4
-        extensions.extend_from_slice(&[0x00, 0x02]); // Supported groups length: 2
+        extensions.extend_from_slice(&[0x00, 0x0a]); // Extension length: 10
+        extensions.extend_from_slice(&[0x00, 0x08]); // Supported groups length: 8
+        extensions.extend_from_slice(&supported_group_grease.to_be_bytes());
         extensions.extend_from_slice(&[0x00, 0x1d]); // x25519
+        extensions.extend_from_slice(&[0x00, 0x17]); // secp256r1
+        extensions.extend_from_slice(&[0x00, 0x18]); // secp384r1
     }
 
     // key_share extension (type 51)
     {
         extensions.extend_from_slice(&[0x00, 0x33]); // Extension type: key_share
-        let key_share_len = 2 + 4 + client_public_key.len();
+        let grease_key_share_len = 1usize;
+        let key_share_len = 2 + 4 + grease_key_share_len + 4 + client_public_key.len();
         extensions.extend_from_slice(&(key_share_len as u16).to_be_bytes()); // Extension length
-        let key_share_list_len = 4 + client_public_key.len();
+        let key_share_list_len = 4 + grease_key_share_len + 4 + client_public_key.len();
         extensions.extend_from_slice(&(key_share_list_len as u16).to_be_bytes()); // Key share list length
+        extensions.extend_from_slice(&supported_group_grease.to_be_bytes()); // GREASE group
+        extensions.extend_from_slice(&(grease_key_share_len as u16).to_be_bytes());
+        extensions.push(0x00);
         extensions.extend_from_slice(&[0x00, 0x1d]); // Group: x25519
         extensions.extend_from_slice(&(client_public_key.len() as u16).to_be_bytes()); // Key length
         extensions.extend_from_slice(client_public_key); // Public key
@@ -430,6 +496,42 @@ pub fn write_record_header(record_type: u8, length: u16) -> Vec<u8> {
 mod tests {
     use super::*;
     use crate::reality::common::CONTENT_TYPE_HANDSHAKE;
+    use std::collections::HashMap;
+
+    fn parse_client_hello(hello: &[u8]) -> (Vec<u16>, HashMap<u16, Vec<u8>>) {
+        let mut offset = 1 + 3 + 2 + 32;
+        let session_id_len = hello[offset] as usize;
+        offset += 1 + session_id_len;
+
+        let cipher_suites_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
+        offset += 2;
+        let cipher_suites = hello[offset..offset + cipher_suites_len]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        offset += cipher_suites_len;
+
+        let compression_methods_len = hello[offset] as usize;
+        offset += 1 + compression_methods_len;
+
+        let extensions_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
+        offset += 2;
+        let extensions_end = offset + extensions_len;
+
+        let mut extensions = HashMap::new();
+        while offset < extensions_end {
+            let extension_type = u16::from_be_bytes([hello[offset], hello[offset + 1]]);
+            let extension_len = u16::from_be_bytes([hello[offset + 2], hello[offset + 3]]) as usize;
+            offset += 4;
+            extensions.insert(
+                extension_type,
+                hello[offset..offset + extension_len].to_vec(),
+            );
+            offset += extension_len;
+        }
+
+        (cipher_suites, extensions)
+    }
 
     #[test]
     fn test_construct_server_hello() {
@@ -500,28 +602,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut offset = 1 + 3 + 2 + 32;
-        let session_id_len = hello[offset] as usize;
-        offset += 1 + session_id_len;
-        let cipher_suites_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
-        offset += 2 + cipher_suites_len;
-        let compression_methods_len = hello[offset] as usize;
-        offset += 1 + compression_methods_len;
-        let extensions_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
-        offset += 2;
-        let extensions_end = offset + extensions_len;
-
-        let mut signature_algorithms = None;
-        while offset < extensions_end {
-            let extension_type = u16::from_be_bytes([hello[offset], hello[offset + 1]]);
-            let extension_len = u16::from_be_bytes([hello[offset + 2], hello[offset + 3]]) as usize;
-            offset += 4;
-            if extension_type == 0x000d {
-                signature_algorithms = Some(&hello[offset..offset + extension_len]);
-                break;
-            }
-            offset += extension_len;
-        }
+        let (_cipher_suites, extensions) = parse_client_hello(&hello);
+        let signature_algorithms = extensions.get(&0x000d).map(Vec::as_slice);
 
         let extension = signature_algorithms.expect("missing signature_algorithms extension");
         assert_eq!(u16::from_be_bytes([extension[0], extension[1]]), 16);
@@ -537,6 +619,109 @@ mod tests {
                 0x08, 0x06, // rsa_pss_rsae_sha512
                 0x06, 0x01, // rsa_pkcs1_sha512
             ]
+        );
+    }
+
+    #[test]
+    fn test_client_hello_default_cipher_suites_are_chrome_like() {
+        let client_random = [0u8; 32];
+        let session_id = [0u8; 32];
+        let client_public_key = [0u8; 32];
+
+        let hello = construct_client_hello(
+            &client_random,
+            &session_id,
+            &client_public_key,
+            "example.com",
+            &[0x1301, 0x1302, 0x1303],
+            DEFAULT_ALPN_PROTOCOLS,
+        )
+        .unwrap();
+
+        let (cipher_suites, _extensions) = parse_client_hello(&hello);
+        assert!(is_grease_value(cipher_suites[0]));
+        assert!(cipher_suites.contains(&0x1301));
+        assert!(cipher_suites.contains(&0x1302));
+        assert!(cipher_suites.contains(&0x1303));
+        assert!(cipher_suites.contains(&0xc02b));
+        assert!(cipher_suites.contains(&0xc02f));
+        assert!(cipher_suites.contains(&0xcca9));
+        assert!(cipher_suites.contains(&0x002f));
+    }
+
+    #[test]
+    fn test_client_hello_default_extensions_cover_browser_groups_and_grease() {
+        let client_random = [0u8; 32];
+        let session_id = [0u8; 32];
+        let client_public_key = [0x42u8; 32];
+
+        let hello = construct_client_hello(
+            &client_random,
+            &session_id,
+            &client_public_key,
+            "example.com",
+            &[0x1301, 0x1302, 0x1303],
+            DEFAULT_ALPN_PROTOCOLS,
+        )
+        .unwrap();
+
+        let (_cipher_suites, extensions) = parse_client_hello(&hello);
+        assert!(
+            extensions
+                .keys()
+                .any(|extension| is_grease_value(*extension))
+        );
+        assert!(extensions.contains_key(&0x0000)); // server_name
+        assert!(extensions.contains_key(&0x000a)); // supported_groups
+        assert!(extensions.contains_key(&0x000d)); // signature_algorithms
+        assert!(extensions.contains_key(&0x0010)); // alpn
+        assert!(extensions.contains_key(&0x002b)); // supported_versions
+        assert!(extensions.contains_key(&0x0033)); // key_share
+
+        let supported_groups = extensions.get(&0x000a).expect("missing supported_groups");
+        assert_eq!(
+            u16::from_be_bytes([supported_groups[0], supported_groups[1]]),
+            8
+        );
+        let groups: Vec<u16> = supported_groups[2..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        assert!(is_grease_value(groups[0]));
+        assert!(groups.contains(&0x001d)); // x25519
+        assert!(groups.contains(&0x0017)); // secp256r1
+        assert!(groups.contains(&0x0018)); // secp384r1
+
+        let supported_versions = extensions.get(&0x002b).expect("missing supported_versions");
+        assert_eq!(supported_versions[0], 6);
+        let versions: Vec<u16> = supported_versions[1..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        assert!(is_grease_value(versions[0]));
+        assert!(versions.contains(&0x0304)); // TLS 1.3
+        assert!(versions.contains(&0x0303)); // TLS 1.2
+
+        let key_share = extensions.get(&0x0033).expect("missing key_share");
+        let list_len = u16::from_be_bytes([key_share[0], key_share[1]]) as usize;
+        assert_eq!(list_len, key_share.len() - 2);
+        let first_group = u16::from_be_bytes([key_share[2], key_share[3]]);
+        let first_key_len = u16::from_be_bytes([key_share[4], key_share[5]]) as usize;
+        assert!(is_grease_value(first_group));
+        assert_eq!(first_key_len, 1);
+
+        let x25519_offset = 6 + first_key_len;
+        assert_eq!(
+            u16::from_be_bytes([key_share[x25519_offset], key_share[x25519_offset + 1]]),
+            0x001d
+        );
+        assert_eq!(
+            u16::from_be_bytes([key_share[x25519_offset + 2], key_share[x25519_offset + 3]]),
+            32
+        );
+        assert_eq!(
+            &key_share[x25519_offset + 4..x25519_offset + 36],
+            &client_public_key
         );
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -8,13 +9,17 @@ use std::time::{Duration, Instant};
 
 use futures::future::{FutureExt, Shared};
 use log::debug;
+use lru::LruCache;
 use parking_lot::Mutex;
-use rustc_hash::FxHashMap;
 use tokio::sync::{Mutex as AsyncMutex, RwLock};
 
 use crate::address::{NetLocation, ResolvedLocation};
 
 type ResolveFuture = Pin<Box<dyn Future<Output = std::io::Result<Vec<SocketAddr>>> + Send>>;
+
+const CACHING_NATIVE_RESOLVER_CACHE_CAPACITY: usize = 65_536;
+const RESOLVER_CACHE_CAPACITY: usize = 4_096;
+const RESOLVER_PENDING_CAPACITY: usize = 256;
 
 pub trait Resolver: Send + Sync + Debug {
     fn resolve_location(&self, location: &NetLocation) -> ResolveFuture;
@@ -303,7 +308,7 @@ pub async fn resolve_location(
 /// Uses tokio::net::lookup_host (OS resolver) with TTL-based cache.
 /// This is used as the default resolver when no DNS config is specified.
 pub struct CachingNativeResolver {
-    cache: Arc<parking_lot::Mutex<FxHashMap<NetLocation, CachedResolveResult>>>,
+    cache: Arc<parking_lot::Mutex<LruCache<NetLocation, CachedResolveResult>>>,
     result_timeout_secs: u64,
 }
 
@@ -329,7 +334,9 @@ impl CachingNativeResolver {
 
     pub fn with_timeout(result_timeout_secs: u64) -> Self {
         Self {
-            cache: Arc::new(parking_lot::Mutex::new(FxHashMap::default())),
+            cache: Arc::new(parking_lot::Mutex::new(LruCache::new(
+                NonZeroUsize::new(CACHING_NATIVE_RESOLVER_CACHE_CAPACITY).unwrap(),
+            ))),
             result_timeout_secs,
         }
     }
@@ -345,7 +352,7 @@ impl Resolver for CachingNativeResolver {
     fn resolve_location(&self, location: &NetLocation) -> ResolveFuture {
         // Check cache first
         {
-            let cache = self.cache.lock();
+            let mut cache = self.cache.lock();
             if let Some(cached) = cache.get(location)
                 && Instant::now().duration_since(cached.timestamp)
                     <= Duration::from_secs(self.result_timeout_secs)
@@ -353,6 +360,7 @@ impl Resolver for CachingNativeResolver {
                 let addr = cached.addr;
                 return Box::pin(async move { Ok(vec![addr]) });
             }
+            cache.pop(location);
         }
 
         let location = location.clone();
@@ -373,7 +381,7 @@ impl Resolver for CachingNativeResolver {
             }
 
             // Cache the first result
-            cache.lock().insert(
+            cache.lock().put(
                 location,
                 CachedResolveResult {
                     timestamp: Instant::now(),
@@ -398,9 +406,9 @@ type SharedResolveFuture =
 pub struct ResolverCache {
     resolver: Arc<dyn Resolver>,
     /// Completed resolution results with timestamps
-    cache: FxHashMap<NetLocation, (Instant, SocketAddr)>,
+    cache: LruCache<NetLocation, (Instant, SocketAddr)>,
     /// In-flight resolutions using Shared futures for proper waker handling
-    pending: FxHashMap<NetLocation, SharedResolveFuture>,
+    pending: LruCache<NetLocation, SharedResolveFuture>,
     result_timeout_secs: u64,
 }
 
@@ -414,8 +422,8 @@ impl ResolverCache {
     pub fn new_with_timeout(resolver: Arc<dyn Resolver>, result_timeout_secs: u64) -> Self {
         Self {
             resolver,
-            cache: FxHashMap::default(),
-            pending: FxHashMap::default(),
+            cache: LruCache::new(NonZeroUsize::new(RESOLVER_CACHE_CAPACITY).unwrap()),
+            pending: LruCache::new(NonZeroUsize::new(RESOLVER_PENDING_CAPACITY).unwrap()),
             result_timeout_secs,
         }
     }
@@ -432,7 +440,7 @@ impl ResolverCache {
             if Instant::now().duration_since(*ts) <= Duration::from_secs(self.result_timeout_secs) {
                 return Ok(*addr);
             }
-            self.cache.remove(target);
+            self.cache.pop(target);
         }
 
         // Resolve
@@ -443,7 +451,7 @@ impl ResolverCache {
             )));
         }
         let addr = addrs[0];
-        self.cache.insert(target.clone(), (Instant::now(), addr));
+        self.cache.put(target.clone(), (Instant::now(), addr));
         Ok(addr)
     }
 
@@ -464,36 +472,42 @@ impl ResolverCache {
             if Instant::now().duration_since(*ts) <= Duration::from_secs(self.result_timeout_secs) {
                 return Poll::Ready(Ok(*addr));
             }
-            self.cache.remove(target);
+            self.cache.pop(target);
         }
 
         // Get or create shared future for this target
-        let mut shared_fut = self
-            .pending
-            .entry(target.clone())
-            .or_insert_with(|| {
+        let mut shared_fut = if let Some(shared_fut) = self.pending.get(target).cloned() {
+            shared_fut
+        } else {
+            if self.pending.len() >= RESOLVER_PENDING_CAPACITY {
+                return Poll::Ready(Err(std::io::Error::other("resolver pending cache full")));
+            }
+
+            let shared_fut = {
                 let fut = self.resolver.resolve_location(target);
                 // Wrap error in Arc for Clone requirement, then make shared
                 fut.map(|r| r.map_err(Arc::new)).boxed().shared()
-            })
-            .clone();
+            };
+            self.pending.put(target.clone(), shared_fut.clone());
+            shared_fut
+        };
 
         // Poll the shared future
         match shared_fut.poll_unpin(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(addrs)) => {
-                self.pending.remove(target);
+                self.pending.pop(target);
                 if addrs.is_empty() {
                     return Poll::Ready(Err(std::io::Error::other(format!(
                         "DNS lookup returned no addresses for {target}"
                     ))));
                 }
                 let addr = addrs[0];
-                self.cache.insert(target.clone(), (Instant::now(), addr));
+                self.cache.put(target.clone(), (Instant::now(), addr));
                 Poll::Ready(Ok(addr))
             }
             Poll::Ready(Err(e)) => {
-                self.pending.remove(target);
+                self.pending.pop(target);
                 // Convert Arc<Error> back to Error
                 Poll::Ready(Err(std::io::Error::new(e.kind(), e.to_string())))
             }

--- a/src/shadow_tls/shadow_tls_server_handler.rs
+++ b/src/shadow_tls/shadow_tls_server_handler.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 use std::io::Cursor;
 use std::sync::Arc;
 
+use subtle::ConstantTimeEq;
 use tokio::io::AsyncWriteExt;
 
 use super::shadow_tls_hmac::ShadowTlsHmac;
@@ -106,6 +107,11 @@ const RETRY_REQUEST_RANDOM_BYTES: [u8; 32] = [
     0xC2, 0xA2, 0x11, 0x16, 0x7A, 0xBB, 0x8C, 0x5E, 0x07, 0x9E, 0x09, 0xE2, 0xC8, 0xA8, 0x33, 0x9C,
 ];
 
+#[inline]
+fn hmac_tag_matches(actual: &[u8], expected: [u8; 4]) -> bool {
+    actual.len() == 4 && expected.as_ref().ct_eq(actual).unwrap_u8() == 1
+}
+
 /// Validates the ClientHello for ShadowTLS authentication.
 /// Returns Ok(()) on success, or Err with PermissionDenied on auth failure.
 fn validate_shadowtls_client_hello(
@@ -167,7 +173,7 @@ fn validate_shadowtls_client_hello(
     hmac.update(&[0; 4]);
     hmac.update(&client_hello_frame[digest.client_hello_digest_end_index..]);
 
-    if digest.client_hello_digest != hmac.finalized_digest() {
+    if !hmac_tag_matches(&digest.client_hello_digest, hmac.finalized_digest()) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "HMAC tag mismatch",
@@ -869,11 +875,11 @@ async fn setup_remote_handshake(
                         format!("failed to read TLS payload from client during handshake (size {client_payload_size}): {e}")
                     ))?;
 
-                if client_content_type == CONTENT_TYPE_APPLICATION_DATA {
+                if client_content_type == CONTENT_TYPE_APPLICATION_DATA && client_payload_bytes.len() >= 4 {
                     let mut tmp_hmac = hmac_client_data.clone();
                     tmp_hmac.update(&client_payload_bytes[4..]);
 
-                    if tmp_hmac.finalized_digest() == client_payload_bytes[..4] {
+                    if hmac_tag_matches(&client_payload_bytes[..4], tmp_hmac.finalized_digest()) {
                         let initial_client_data = &client_payload_bytes[4..];
 
                         hmac_client_data.update(initial_client_data);
@@ -1115,11 +1121,11 @@ async fn setup_local_handshake(
             .read_slice(&mut server_stream, client_payload_size as usize)
             .await?;
 
-        if client_content_type == CONTENT_TYPE_APPLICATION_DATA {
+        if client_content_type == CONTENT_TYPE_APPLICATION_DATA && client_payload_bytes.len() >= 4 {
             let mut tmp_hmac = hmac_client_data.clone();
             tmp_hmac.update(&client_payload_bytes[4..]);
 
-            if tmp_hmac.finalized_digest() == client_payload_bytes[..4] {
+            if hmac_tag_matches(&client_payload_bytes[..4], tmp_hmac.finalized_digest()) {
                 let initial_client_data = &client_payload_bytes[4..];
 
                 hmac_client_data.update(initial_client_data);
@@ -1172,6 +1178,22 @@ fn read_server_connection(
             })?;
     }
     Ok(server_data_cursor.position() as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_tag_match_rejects_short_actual_tag() {
+        assert!(!hmac_tag_matches(&[], [0, 0, 0, 0]));
+        assert!(!hmac_tag_matches(&[0, 0, 0], [0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn hmac_tag_match_accepts_exact_match() {
+        assert!(hmac_tag_matches(&[1, 2, 3, 4], [1, 2, 3, 4]));
+    }
 }
 
 #[inline]

--- a/src/shadow_tls/shadow_tls_stream.rs
+++ b/src/shadow_tls/shadow_tls_stream.rs
@@ -129,6 +129,16 @@ impl ShadowTlsStream {
         }
     }
 
+    fn discard_unprocessed_frame(&mut self, total_len: usize) {
+        if total_len < self.unprocessed_end_offset {
+            self.unprocessed_buf
+                .copy_within(total_len..self.unprocessed_end_offset, 0);
+            self.unprocessed_end_offset -= total_len;
+        } else {
+            self.unprocessed_end_offset = 0;
+        }
+    }
+
     #[inline]
     fn try_deframe(&mut self) -> std::io::Result<DeframeState> {
         // we should only deframe when there is no readily available processed data.
@@ -221,6 +231,11 @@ impl ShadowTlsStream {
         }
         self.read_hmac.update(&expected_digest);
 
+        if payload_len == 0 {
+            self.discard_unprocessed_frame(total_len);
+            return Ok(DeframeState::SkippedFrame);
+        }
+
         self.processed_buf[0..payload_len].copy_from_slice(payload);
         self.processed_end_offset = payload_len;
 
@@ -241,6 +256,7 @@ enum DeframeState {
     Success,
     ReceivedAlert,
     HandshakeFrame,
+    SkippedFrame,
 }
 
 impl AsyncRead for ShadowTlsStream {
@@ -268,7 +284,7 @@ impl AsyncRead for ShadowTlsStream {
                     }
                     DeframeState::NeedData => break,
                     DeframeState::ReceivedAlert => return Poll::Ready(Ok(())),
-                    DeframeState::HandshakeFrame => {}
+                    DeframeState::HandshakeFrame | DeframeState::SkippedFrame => {}
                 }
             }
 
@@ -297,7 +313,7 @@ impl AsyncRead for ShadowTlsStream {
                             }
                             DeframeState::NeedData => break,
                             DeframeState::ReceivedAlert => return Poll::Ready(Ok(())),
-                            DeframeState::HandshakeFrame => {}
+                            DeframeState::HandshakeFrame | DeframeState::SkippedFrame => {}
                         }
                     }
                 }
@@ -335,6 +351,10 @@ impl AsyncWrite for ShadowTlsStream {
 
         this.write_buf_pos = 0;
         this.write_buf_end = 0;
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
 
         let consumed_buf_len = std::cmp::min(buf.len(), MAX_WRITE_PAYLOAD_LEN);
         let consumed_buf = &buf[0..consumed_buf_len];
@@ -408,3 +428,102 @@ impl AsyncPing for ShadowTlsStream {
 }
 
 impl AsyncStream for ShadowTlsStream {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_lc_rs::hmac::{HMAC_SHA256, Key};
+
+    struct TestStream;
+
+    impl AsyncRead for TestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncPing for TestStream {
+        fn supports_ping(&self) -> bool {
+            false
+        }
+
+        fn poll_write_ping(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<bool>> {
+            Poll::Ready(Ok(false))
+        }
+    }
+
+    impl AsyncStream for TestStream {}
+
+    fn encode_application_data_frame(hmac: &mut ShadowTlsHmac, payload: &[u8]) -> Vec<u8> {
+        hmac.update(payload);
+        let digest = hmac.digest();
+        hmac.update(&digest);
+
+        let frame_len = payload.len() + 4;
+        let mut frame = Vec::with_capacity(TLS_HEADER_LEN + frame_len);
+        frame.extend_from_slice(&[
+            CONTENT_TYPE_APPLICATION_DATA,
+            0x03,
+            0x03,
+            (frame_len >> 8) as u8,
+            frame_len as u8,
+        ]);
+        frame.extend_from_slice(&digest);
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    #[test]
+    fn zero_payload_application_frame_is_skipped_without_losing_next_frame() {
+        let key = Key::new(HMAC_SHA256, b"shadow-tls-test-key");
+        let mut peer_hmac = ShadowTlsHmac::new(&key);
+        let mut frames = encode_application_data_frame(&mut peer_hmac, b"");
+        frames.extend_from_slice(&encode_application_data_frame(&mut peer_hmac, b"ok"));
+
+        let mut stream = ShadowTlsStream::new(
+            Box::new(TestStream),
+            &[],
+            ShadowTlsHmac::new(&key),
+            ShadowTlsHmac::new(&key),
+            None,
+        )
+        .unwrap();
+        stream.feed_initial_read_data(&frames).unwrap();
+
+        assert!(matches!(
+            stream.try_deframe().unwrap(),
+            DeframeState::SkippedFrame
+        ));
+        assert_eq!(stream.unprocessed_end_offset, TLS_HEADER_LEN + 6);
+        assert!(matches!(
+            stream.try_deframe().unwrap(),
+            DeframeState::Success
+        ));
+        assert_eq!(&stream.processed_buf[..2], b"ok");
+    }
+}

--- a/src/shadowsocks/shadowsocks_stream.rs
+++ b/src/shadowsocks/shadowsocks_stream.rs
@@ -442,20 +442,16 @@ impl ShadowsocksStream {
                 let timestamp_bytes = &self.unprocessed_buf[self.salt_len + 1..self.salt_len + 9];
                 let timestamp_secs = u64::from_be_bytes(timestamp_bytes.try_into().unwrap());
                 let current_time_secs = current_time_secs();
-                if current_time_secs >= timestamp_secs {
-                    if current_time_secs - timestamp_secs > 30 {
-                        return Err(std::io::Error::other(
-                            "timestamp is greater than 30 seconds",
-                        ));
-                    }
-                } else {
-                    // Make sure times aren't too far in the future.
-                    if timestamp_secs - current_time_secs > 2 {
-                        return Err(std::io::Error::other(format!(
-                            "timestamp is {} seconds in the future",
-                            timestamp_secs - current_time_secs
-                        )));
-                    }
+                // SIP022 (Shadowsocks 2022 Edition) requires rejecting any header
+                // whose timestamp is more than 30 seconds away from the current
+                // time, in either direction. Enforce the same symmetric window so
+                // peers with a fast clock (NTP drift, virtualized hosts) aren't
+                // rejected for being more than a couple of seconds ahead.
+                let time_diff_secs = current_time_secs.abs_diff(timestamp_secs);
+                if time_diff_secs > 30 {
+                    return Err(std::io::Error::other(format!(
+                        "timestamp is {time_diff_secs} seconds away from the current time"
+                    )));
                 }
 
                 let decrypt_iv = &self.unprocessed_buf[0..self.salt_len];
@@ -509,20 +505,16 @@ impl ShadowsocksStream {
                 let timestamp_bytes = &self.unprocessed_buf[self.salt_len + 1..self.salt_len + 9];
                 let timestamp_secs = u64::from_be_bytes(timestamp_bytes.try_into().unwrap());
                 let current_time_secs = current_time_secs();
-                if current_time_secs >= timestamp_secs {
-                    if current_time_secs - timestamp_secs > 30 {
-                        return Err(std::io::Error::other(
-                            "timestamp is greater than 30 seconds",
-                        ));
-                    }
-                } else {
-                    // Make sure times aren't too far in the future.
-                    if timestamp_secs - current_time_secs > 2 {
-                        return Err(std::io::Error::other(format!(
-                            "timestamp is {} seconds in the future",
-                            timestamp_secs - current_time_secs
-                        )));
-                    }
+                // SIP022 (Shadowsocks 2022 Edition) requires rejecting any header
+                // whose timestamp is more than 30 seconds away from the current
+                // time, in either direction. Enforce the same symmetric window so
+                // peers with a fast clock (NTP drift, virtualized hosts) aren't
+                // rejected for being more than a couple of seconds ahead.
+                let time_diff_secs = current_time_secs.abs_diff(timestamp_secs);
+                if time_diff_secs > 30 {
+                    return Err(std::io::Error::other(format!(
+                        "timestamp is {time_diff_secs} seconds away from the current time"
+                    )));
                 }
 
                 if let Some(salt_checker) = &self.salt_checker {

--- a/src/shadowsocks/shadowsocks_stream.rs
+++ b/src/shadowsocks/shadowsocks_stream.rs
@@ -441,7 +441,7 @@ impl ShadowsocksStream {
 
                 let timestamp_bytes = &self.unprocessed_buf[self.salt_len + 1..self.salt_len + 9];
                 let timestamp_secs = u64::from_be_bytes(timestamp_bytes.try_into().unwrap());
-                let current_time_secs = current_time_secs();
+                let current_time_secs = current_time_secs()?;
                 // SIP022 (Shadowsocks 2022 Edition) requires rejecting any header
                 // whose timestamp is more than 30 seconds away from the current
                 // time, in either direction. Enforce the same symmetric window so
@@ -504,7 +504,7 @@ impl ShadowsocksStream {
 
                 let timestamp_bytes = &self.unprocessed_buf[self.salt_len + 1..self.salt_len + 9];
                 let timestamp_secs = u64::from_be_bytes(timestamp_bytes.try_into().unwrap());
-                let current_time_secs = current_time_secs();
+                let current_time_secs = current_time_secs()?;
                 // SIP022 (Shadowsocks 2022 Edition) requires rejecting any header
                 // whose timestamp is more than 30 seconds away from the current
                 // time, in either direction. Enforce the same symmetric window so
@@ -582,7 +582,7 @@ impl ShadowsocksStream {
 
                 // HeaderTypeServerStream = 1
                 response_header[0] = 1;
-                response_header[1..9].copy_from_slice(&current_time_secs().to_be_bytes());
+                response_header[1..9].copy_from_slice(&current_time_secs()?.to_be_bytes());
                 response_header[9..9 + self.salt_len].copy_from_slice(&decrypt_iv);
 
                 let handled_len = std::cmp::min(
@@ -615,7 +615,7 @@ impl ShadowsocksStream {
 
                 // HeaderTypeClientStream = 0
                 request_header[0] = 0;
-                request_header[1..9].copy_from_slice(&current_time_secs().to_be_bytes());
+                request_header[1..9].copy_from_slice(&current_time_secs()?.to_be_bytes());
 
                 // This is a bit hacky. We expect/know that the first packet will be the "variable-length header"
                 // with the address and padding, and we need to send it all off in a single packet.
@@ -901,6 +901,9 @@ impl AsyncStream for ShadowsocksStream {}
 impl AsyncMessageStream for ShadowsocksStream {}
 
 #[inline]
-fn current_time_secs() -> u64 {
-    SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs()
+fn current_time_secs() -> std::io::Result<u64> {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .map_err(|e| std::io::Error::other(format!("system time before unix epoch: {e}")))
 }

--- a/src/shadowsocks/shadowsocks_tcp_handler.rs
+++ b/src/shadowsocks/shadowsocks_tcp_handler.rs
@@ -29,6 +29,8 @@ use super::shadowsocks_key::ShadowsocksKey;
 use super::shadowsocks_stream::ShadowsocksStream;
 use super::shadowsocks_stream_type::ShadowsocksStreamType;
 
+const AEAD2022_MAX_PADDING_LEN: u16 = 900;
+
 #[derive(Debug)]
 pub struct ShadowsocksTcpHandler {
     cipher: ShadowsocksCipher,
@@ -128,6 +130,17 @@ impl ShadowsocksTcpHandler {
     }
 }
 
+fn validate_aead2022_tcp_padding_len(padding_len: u16) -> std::io::Result<()> {
+    if padding_len > AEAD2022_MAX_PADDING_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid padding length: {padding_len}"),
+        ));
+    }
+
+    Ok(())
+}
+
 #[async_trait]
 impl TcpServerHandler for ShadowsocksTcpHandler {
     async fn setup_server_stream(
@@ -157,17 +170,10 @@ impl TcpServerHandler for ShadowsocksTcpHandler {
         if self.aead2022 {
             let padding_len = stream_reader.read_u16_be(&mut server_stream).await?;
 
-            if padding_len > 0 {
-                if padding_len > 900 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("invalid padding length: {padding_len}"),
-                    ));
-                }
-                stream_reader
-                    .read_slice(&mut server_stream, padding_len as usize)
-                    .await?;
-            }
+            validate_aead2022_tcp_padding_len(padding_len)?;
+            stream_reader
+                .read_slice(&mut server_stream, padding_len as usize)
+                .await?;
         }
 
         // Checks for h2mux magic destination
@@ -329,7 +335,7 @@ impl TcpClientHandler for ShadowsocksTcpHandler {
             let location_len = location_vec.len();
 
             let mut rng = rand::rng();
-            let padding_len: usize = rng.random_range(1..=900);
+            let padding_len: usize = rng.random_range(1..=AEAD2022_MAX_PADDING_LEN as usize);
             location_vec.resize(location_len + padding_len + 2, 0);
 
             let padding_len_bytes = (padding_len as u16).to_be_bytes();
@@ -381,7 +387,7 @@ impl TcpClientHandler for ShadowsocksTcpHandler {
         if self.aead2022 {
             let location_len = location_vec.len();
             let mut rng = rand::rng();
-            let padding_len: usize = rng.random_range(1..=900);
+            let padding_len: usize = rng.random_range(1..=AEAD2022_MAX_PADDING_LEN as usize);
             location_vec.resize(location_len + padding_len + 2, 0);
             let padding_len_bytes = (padding_len as u16).to_be_bytes();
             location_vec[location_len..location_len + 2].copy_from_slice(&padding_len_bytes);
@@ -402,5 +408,27 @@ impl TcpClientHandler for ShadowsocksTcpHandler {
         let message_stream = UotV2Stream::new(client_stream);
 
         Ok(Box::new(message_stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aead2022_tcp_padding_accepts_zero_len() {
+        assert!(validate_aead2022_tcp_padding_len(0).is_ok());
+    }
+
+    #[test]
+    fn aead2022_tcp_padding_rejects_oversized_len() {
+        let err = validate_aead2022_tcp_padding_len(AEAD2022_MAX_PADDING_LEN + 1).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn aead2022_tcp_padding_accepts_expected_len_range() {
+        assert!(validate_aead2022_tcp_padding_len(1).is_ok());
+        assert!(validate_aead2022_tcp_padding_len(AEAD2022_MAX_PADDING_LEN).is_ok());
     }
 }

--- a/src/slide_buffer.rs
+++ b/src/slide_buffer.rs
@@ -102,10 +102,10 @@ impl SlideBuffer {
     /// Extend the buffer with data from a slice.
     ///
     /// # Panics
-    /// Panics in debug mode if there isn't enough capacity.
+    /// Panics if there isn't enough capacity.
     #[inline]
     pub fn extend_from_slice(&mut self, data: &[u8]) {
-        debug_assert!(
+        assert!(
             self.remaining_capacity() >= data.len(),
             "SlideBuffer overflow: need {} bytes, have {}",
             data.len(),
@@ -119,7 +119,7 @@ impl SlideBuffer {
     /// Mark n bytes as written (after writing to `write_slice()`).
     #[inline]
     pub fn advance_write(&mut self, n: usize) {
-        debug_assert!(
+        assert!(
             self.end + n <= self.data.len(),
             "SlideBuffer advance_write overflow: end={}, n={}, capacity={}",
             self.end,
@@ -132,10 +132,10 @@ impl SlideBuffer {
     /// Consume n bytes from the front of the buffer.
     ///
     /// # Panics
-    /// Panics in debug mode if n exceeds the available data.
+    /// Panics if n exceeds the available data.
     #[inline]
     pub fn consume(&mut self, n: usize) {
-        debug_assert!(
+        assert!(
             n <= self.len(),
             "SlideBuffer consume underflow: n={}, len={}",
             n,

--- a/src/socks_handler.rs
+++ b/src/socks_handler.rs
@@ -150,7 +150,7 @@ pub async fn setup_socks_server_stream_inner(
     };
 
     if !methods.contains(&supported_method) {
-        // TODO: consider writing response: [VER_SOCKS5, METHOD_INVALID]
+        let _ = write_all(&mut server_stream, &[VER_SOCKS5, METHOD_INVALID]).await;
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "Supported SOCKS method not found",

--- a/src/stream_worker_pool.rs
+++ b/src/stream_worker_pool.rs
@@ -12,19 +12,25 @@
 //! By limiting the number of spawned tasks to a fixed pool size (e.g., 4-8 workers),
 //! the connection driver has much less competition for scheduler time.
 
-use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use log::{debug, error};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::mpsc;
 
 /// Type alias for boxed futures that the worker pool processes.
 /// Returns `std::io::Result<()>` to match copy_bidirectional and other copy utilities.
 pub type BoxedFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'static>>;
+
+/// Maximum queued submissions per worker.
+const WORKER_CHANNEL_CAPACITY: usize = 256;
+
+/// Maximum in-flight futures each worker will keep in its local FuturesUnordered.
+const MAX_IN_FLIGHT_PER_WORKER: usize = 256;
 
 /// A pool of worker tasks that process futures without spawning per-future tasks.
 ///
@@ -36,7 +42,7 @@ pub type BoxedFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'sta
 /// the same pool.
 pub struct StreamWorkerPool {
     /// Senders to each worker, for round-robin distribution
-    senders: Vec<mpsc::UnboundedSender<BoxedFuture>>,
+    senders: Vec<mpsc::Sender<BoxedFuture>>,
     /// Counter for round-robin distribution
     next_worker: AtomicUsize,
 }
@@ -58,7 +64,7 @@ impl StreamWorkerPool {
         let mut senders = Vec::with_capacity(num_workers);
 
         for worker_id in 0..num_workers {
-            let (tx, rx) = mpsc::unbounded_channel::<BoxedFuture>();
+            let (tx, rx) = mpsc::channel::<BoxedFuture>(WORKER_CHANNEL_CAPACITY);
             senders.push(tx);
 
             tokio::spawn(worker_loop(worker_id, rx));
@@ -77,14 +83,14 @@ impl StreamWorkerPool {
     /// and other copy utilities. Errors are logged by the worker.
     ///
     /// Returns `true` if the future was successfully submitted, `false` if
-    /// the worker channel is closed (worker task has terminated).
+    /// the worker channel is full or closed.
     pub fn submit<F>(&self, future: F) -> bool
     where
         F: Future<Output = io::Result<()>> + Send + 'static,
     {
         // Round-robin distribution
         let worker_idx = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.senders.len();
-        self.senders[worker_idx].send(Box::pin(future)).is_ok()
+        self.senders[worker_idx].try_send(Box::pin(future)).is_ok()
     }
 
     /// Returns the number of workers in the pool.
@@ -94,7 +100,7 @@ impl StreamWorkerPool {
 }
 
 /// The worker loop that processes futures from the channel.
-async fn worker_loop(worker_id: usize, mut rx: mpsc::UnboundedReceiver<BoxedFuture>) {
+async fn worker_loop(worker_id: usize, mut rx: mpsc::Receiver<BoxedFuture>) {
     let mut futures: FuturesUnordered<BoxedFuture> = FuturesUnordered::new();
     let mut yield_counter: u8 = 0;
 
@@ -115,7 +121,7 @@ async fn worker_loop(worker_id: usize, mut rx: mpsc::UnboundedReceiver<BoxedFutu
                 }
             }
             // Accept new futures from the channel (lower priority)
-            Some(future) = rx.recv() => {
+            Some(future) = rx.recv(), if futures.len() < MAX_IN_FLIGHT_PER_WORKER => {
                 futures.push(future);
             }
             // Channel closed and no more futures to process

--- a/src/thread_util.rs
+++ b/src/thread_util.rs
@@ -7,5 +7,5 @@ pub fn set_num_threads(num_threads: usize) {
 }
 
 pub fn get_num_threads() -> usize {
-    *NUM_THREADS.get().unwrap()
+    NUM_THREADS.get().copied().unwrap_or(1).max(1)
 }

--- a/src/tuic_server.rs
+++ b/src/tuic_server.rs
@@ -8,8 +8,10 @@ use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
 use log::{debug, error};
 use lru::LruCache;
+use subtle::ConstantTimeEq;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
@@ -41,6 +43,9 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Old entries are automatically evicted when this limit is reached.
 const MAX_FRAGMENT_CACHE_SIZE: usize = 256;
 
+/// Maximum UDP sessions per authenticated connection.
+const MAX_TUIC_UDP_SESSIONS: usize = 4096;
+
 /// Authentication timeout - close connection if client doesn't authenticate within this time.
 /// Default is 3 seconds per sing-box reference implementation.
 const AUTH_TIMEOUT: Duration = Duration::from_secs(3);
@@ -50,6 +55,19 @@ const AUTH_TIMEOUT: Duration = Duration::from_secs(3);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
 type UdpSessionMap = Arc<DashMap<u16, UdpSession>>;
+type FragmentCacheKey = (u16, u16);
+type FragmentCache = LruCache<FragmentCacheKey, FragmentedPacket>;
+type SharedFragmentCache = Arc<Mutex<FragmentCache>>;
+
+enum FragmentCacheAccess<'a> {
+    Local(&'a mut FragmentCache),
+    Shared(SharedFragmentCache),
+}
+
+#[inline]
+fn secret_bytes_match(expected: &[u8], actual: &[u8]) -> bool {
+    expected.ct_eq(actual).unwrap_u8() == 1
+}
 
 async fn process_connection(
     client_proxy_selector: Arc<ClientProxySelector>,
@@ -225,14 +243,14 @@ async fn auth_connection(
         }
 
         let specified_uuid = stream_reader.read_slice(&mut recv_stream, 16).await?;
-        if specified_uuid != uuid {
+        if !secret_bytes_match(uuid, specified_uuid) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                format!("incorrect uuid: {specified_uuid:?}"),
+                "incorrect uuid",
             ));
         }
         let token_bytes = stream_reader.read_slice(&mut recv_stream, 32).await?;
-        if token_bytes != expected_token_bytes {
+        if !secret_bytes_match(expected_token_bytes.as_ref(), token_bytes) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 "incorrect token",
@@ -490,6 +508,15 @@ struct FragmentedPacket {
     packet_len: usize,
     received: Vec<Option<Bytes>>,
     remote_location: Option<NetLocation>,
+}
+
+struct ReassembledPacket {
+    remote_location: NetLocation,
+    payload: Vec<u8>,
+}
+
+fn new_fragment_cache() -> FragmentCache {
+    LruCache::new(NonZeroUsize::new(MAX_FRAGMENT_CACHE_SIZE).unwrap())
 }
 
 impl UdpSession {
@@ -767,6 +794,12 @@ async fn run_udp_remote_to_local_datagram_loop(
         // + payload_size (2 bytes) + address_bytes
         let header_overhead = 1 + 1 + 2 + 2 + 1 + 1 + 2 + address_bytes_len;
 
+        if max_datagram_size <= header_overhead {
+            return Err(std::io::Error::other(format!(
+                "max datagram size ({max_datagram_size}) is smaller than header overhead ({header_overhead})"
+            )));
+        }
+
         if header_overhead + payload_len <= max_datagram_size {
             let mut datagram = BytesMut::with_capacity(header_overhead + payload_len);
             datagram.put_u8(5); // tuic version
@@ -792,6 +825,9 @@ async fn run_udp_remote_to_local_datagram_loop(
             let remaining = payload_len.saturating_sub(first_capacity);
             let additional_fragments = remaining.div_ceil(other_capacity);
             let fragment_count = 1 + additional_fragments;
+            if fragment_count > u8::MAX as usize {
+                return Err(std::io::Error::other("too many UDP fragments"));
+            }
 
             let mut offset = 0;
             for fragment_id in 0..fragment_count {
@@ -832,6 +868,8 @@ async fn run_unidirectional_loop(
     udp_session_map: UdpSessionMap,
     cancel_token: CancellationToken,
 ) -> std::io::Result<()> {
+    let fragment_cache: SharedFragmentCache = Arc::new(Mutex::new(new_fragment_cache()));
+
     // Spawn a cleanup task for UDP sessions that terminates when connection closes
     let cleanup_session_map = udp_session_map.clone();
     let cleanup_cancel_token = cancel_token.clone();
@@ -878,6 +916,7 @@ async fn run_unidirectional_loop(
         let client_proxy_selector = client_proxy_selector.clone();
         let resolver = resolver.clone();
         let udp_session_map = udp_session_map.clone();
+        let fragment_cache = fragment_cache.clone();
         let cancel_token = cancel_token.clone();
         tokio::spawn(async move {
             // Per TUIC protocol, each uni stream carries exactly ONE command.
@@ -888,6 +927,7 @@ async fn run_unidirectional_loop(
                 resolver,
                 recv_stream,
                 udp_session_map,
+                fragment_cache,
                 cancel_token,
             )
             .await
@@ -913,6 +953,7 @@ async fn process_uni_stream(
     resolver: Arc<dyn Resolver>,
     mut recv_stream: quinn::RecvStream,
     udp_session_map: UdpSessionMap,
+    fragment_cache: SharedFragmentCache,
     cancel_token: CancellationToken,
 ) -> std::io::Result<()> {
     let mut stream_reader = StreamReader::new_with_buffer_size(MAX_HEADER_LEN + 65535);
@@ -954,21 +995,12 @@ async fn process_uni_stream(
         .read_slice(&mut recv_stream, payload_size as usize)
         .await?;
 
-    // For uni stream packets, we need per-connection fragment reassembly.
-    // Since each stream is one packet, fragments come on separate streams.
-    // We use the connection-level udp_session_map for this.
-    // Note: Fragment reassembly for uni streams is handled at the session level.
-    // For simplicity, we only support non-fragmented packets on uni streams for now,
-    // or let process_udp_packet handle it with a temporary fragment cache.
-    let mut fragments: LruCache<u16, FragmentedPacket> =
-        LruCache::new(NonZeroUsize::new(MAX_FRAGMENT_CACHE_SIZE).unwrap());
-
     process_udp_packet(
         connection,
         &client_proxy_selector,
         &resolver,
         &udp_session_map,
-        &mut fragments,
+        FragmentCacheAccess::Shared(fragment_cache),
         assoc_id,
         packet_id,
         frag_total,
@@ -981,6 +1013,96 @@ async fn process_uni_stream(
     .await
 }
 
+fn record_udp_fragment(
+    fragments: &mut FragmentCache,
+    assoc_id: u16,
+    packet_id: u16,
+    frag_total: u8,
+    frag_id: u8,
+    remote_location: Option<NetLocation>,
+    payload_fragment: &[u8],
+) -> std::io::Result<Option<ReassembledPacket>> {
+    let fragment_key = (assoc_id, packet_id);
+    let is_new = !fragments.contains(&fragment_key);
+
+    if is_new {
+        // Insert new fragmented packet entry
+        fragments.put(
+            fragment_key,
+            FragmentedPacket {
+                fragment_count: frag_total,
+                fragment_received: 0,
+                packet_len: 0,
+                received: vec![None; frag_total as usize],
+                remote_location: remote_location.clone(),
+            },
+        );
+    }
+
+    let packet = match fragments.get_mut(&fragment_key) {
+        Some(p) => p,
+        None => {
+            // This shouldn't happen since we just inserted it
+            return Err(std::io::Error::other("Fragment cache error"));
+        }
+    };
+
+    if frag_id == 0 && packet.remote_location.is_none() {
+        if remote_location.is_none() {
+            fragments.pop(&fragment_key);
+            return Err(std::io::Error::other(format!(
+                "Ignoring packet with empty first fragment address for session {assoc_id}"
+            )));
+        }
+        packet.remote_location = remote_location.clone();
+    }
+
+    if packet.fragment_count != frag_total {
+        fragments.pop(&fragment_key);
+        return Err(std::io::Error::other(format!(
+            "Mismatched fragment count for session {assoc_id} packet {packet_id}"
+        )));
+    }
+    if packet.received[frag_id as usize].is_some() {
+        fragments.pop(&fragment_key);
+        return Err(std::io::Error::other(format!(
+            "Duplicate fragment for session {assoc_id} packet {packet_id}"
+        )));
+    }
+
+    packet.fragment_received += 1;
+    packet.packet_len += payload_fragment.len();
+    packet.received[frag_id as usize] = Some(payload_fragment.to_vec().into());
+
+    if packet.fragment_received != packet.fragment_count {
+        return Ok(None);
+    }
+
+    // All fragments received - remove from cache and process
+    let FragmentedPacket {
+        remote_location,
+        received,
+        packet_len,
+        ..
+    } = fragments.pop(&fragment_key).unwrap();
+
+    let Some(remote_location) = remote_location else {
+        return Err(std::io::Error::other(format!(
+            "Ignoring fragmented packet with empty first fragment address for session {assoc_id}"
+        )));
+    };
+
+    let mut payload = Vec::with_capacity(packet_len);
+    for frag in received.iter() {
+        payload.extend_from_slice(frag.as_ref().unwrap());
+    }
+
+    Ok(Some(ReassembledPacket {
+        remote_location,
+        payload,
+    }))
+}
+
 // TODO: fix too many arguments warning
 #[allow(clippy::too_many_arguments)]
 #[inline]
@@ -989,7 +1111,7 @@ async fn process_udp_packet(
     client_proxy_selector: &Arc<ClientProxySelector>,
     resolver: &Arc<dyn Resolver>,
     udp_session_map: &UdpSessionMap,
-    fragments: &mut LruCache<u16, FragmentedPacket>,
+    fragments: FragmentCacheAccess<'_>,
     assoc_id: u16,
     packet_id: u16,
     frag_total: u8,
@@ -1023,6 +1145,10 @@ async fn process_udp_packet(
                     return Err(std::io::Error::other(
                         "Ignoring packet with unknown session and empty address",
                     ));
+                }
+
+                if udp_session_map.len() >= MAX_TUIC_UDP_SESSIONS {
+                    return Err(std::io::Error::other("TUIC UDP session cap reached"));
                 }
 
                 let remote_location = remote_location.clone().unwrap();
@@ -1146,70 +1272,37 @@ async fn process_udp_packet(
             }
         }
     } else {
-        let is_new = !fragments.contains(&packet_id);
-
-        if is_new {
-            // Insert new fragmented packet entry
-            fragments.put(
+        let reassembled_packet = match fragments {
+            FragmentCacheAccess::Local(fragments) => record_udp_fragment(
+                fragments,
+                assoc_id,
                 packet_id,
-                FragmentedPacket {
-                    fragment_count: frag_total,
-                    fragment_received: 0,
-                    packet_len: 0,
-                    received: vec![None; frag_total as usize],
-                    remote_location: remote_location.clone(),
-                },
-            );
-        }
-
-        let packet = match fragments.get_mut(&packet_id) {
-            Some(p) => p,
-            None => {
-                // This shouldn't happen since we just inserted it
-                return Err(std::io::Error::other("Fragment cache error"));
+                frag_total,
+                frag_id,
+                remote_location,
+                payload_fragment,
+            )?,
+            FragmentCacheAccess::Shared(fragments) => {
+                let mut fragments = fragments.lock().await;
+                record_udp_fragment(
+                    &mut fragments,
+                    assoc_id,
+                    packet_id,
+                    frag_total,
+                    frag_id,
+                    remote_location,
+                    payload_fragment,
+                )?
             }
         };
 
-        if is_new && frag_id == 0 && packet.remote_location.is_none() {
-            if remote_location.is_none() {
-                fragments.pop(&packet_id);
-                return Err(std::io::Error::other(format!(
-                    "Ignoring packet with empty first fragment address for session {assoc_id}"
-                )));
-            }
-            packet.remote_location = remote_location.clone();
-        }
-
-        if packet.fragment_count != frag_total {
-            fragments.pop(&packet_id);
-            return Err(std::io::Error::other(format!(
-                "Mismatched fragment count for session {assoc_id} packet {packet_id}"
-            )));
-        }
-        if packet.received[frag_id as usize].is_some() {
-            fragments.pop(&packet_id);
-            return Err(std::io::Error::other(format!(
-                "Duplicate fragment for session {assoc_id} packet {packet_id}"
-            )));
-        }
-
-        packet.fragment_received += 1;
-        packet.packet_len += payload_fragment.len();
-        packet.received[frag_id as usize] = Some(payload_fragment.to_vec().into());
-
-        if packet.fragment_received != packet.fragment_count {
-            return Ok(());
-        }
-
-        // All fragments received - remove from cache and process
-        let FragmentedPacket {
+        let Some(ReassembledPacket {
             remote_location,
-            received,
-            packet_len,
-            ..
-        } = fragments.pop(&packet_id).unwrap();
-
-        let remote_location = remote_location.unwrap();
+            payload,
+        }) = reassembled_packet
+        else {
+            return Ok(());
+        };
 
         let (socket_addr, is_updated) = session
             .resolve_address(&remote_location, client_proxy_selector, resolver)
@@ -1220,16 +1313,7 @@ async fn process_udp_packet(
                 ))
             })?;
 
-        let mut complete_payload = Vec::with_capacity(packet_len);
-        for frag in received.iter() {
-            complete_payload.extend_from_slice(frag.as_ref().unwrap());
-        }
-
-        if let Err(e) = session
-            .send_socket
-            .send_to(&complete_payload, socket_addr)
-            .await
-        {
+        if let Err(e) = session.send_socket.send_to(&payload, socket_addr).await {
             error!("Failed to forward UDP payload for session {assoc_id}: {e}");
             drop(session);
             udp_session_map.remove(&assoc_id);
@@ -1248,6 +1332,23 @@ async fn process_udp_packet(
     Ok(())
 }
 
+#[inline]
+fn datagram_payload_fragment(
+    data: &Bytes,
+    offset: usize,
+    payload_size: usize,
+) -> std::io::Result<&[u8]> {
+    let end = offset
+        .checked_add(payload_size)
+        .ok_or_else(|| std::io::Error::other("decode UDP message: payload bounds overflow"))?;
+    if data.len() < end {
+        return Err(std::io::Error::other(
+            "decode UDP message: datagram payload truncated",
+        ));
+    }
+    Ok(&data[offset..end])
+}
+
 async fn run_datagram_loop(
     connection: quinn::Connection,
     client_proxy_selector: Arc<ClientProxySelector>,
@@ -1256,8 +1357,7 @@ async fn run_datagram_loop(
     cancel_token: CancellationToken,
 ) -> std::io::Result<()> {
     // Use LRU cache for fragment reassembly to prevent unbounded memory growth.
-    let mut fragments: LruCache<u16, FragmentedPacket> =
-        LruCache::new(NonZeroUsize::new(MAX_FRAGMENT_CACHE_SIZE).unwrap());
+    let mut fragments = new_fragment_cache();
     let mut last_cleanup = std::time::Instant::now();
 
     loop {
@@ -1324,7 +1424,7 @@ async fn run_datagram_loop(
                     ));
                 }
                 let address_len = data[11] as usize;
-                if data_len < 12 + address_len + 2 + payload_size {
+                if data_len < 12 + address_len + 2 {
                     return Err(std::io::Error::other(
                         "decode UDP message: truncated hostname",
                     ));
@@ -1343,7 +1443,7 @@ async fn run_datagram_loop(
                 (Some(NetLocation::new(address, port)), 12 + address_len + 2)
             }
             0x01 => {
-                if data_len < 17 + payload_size {
+                if data_len < 17 {
                     return Err(std::io::Error::other("decode UDP message: IPv4 too short"));
                 }
                 let ipv4_addr = Ipv4Addr::new(data[11], data[12], data[13], data[14]);
@@ -1351,7 +1451,7 @@ async fn run_datagram_loop(
                 (Some(NetLocation::new(Address::Ipv4(ipv4_addr), port)), 17)
             }
             0x02 => {
-                if data_len < 29 + payload_size {
+                if data_len < 29 {
                     return Err(std::io::Error::other("decode UDP message: IPv6 too short"));
                 }
                 let ipv6_bytes: [u8; 16] = data[11..27].try_into().unwrap();
@@ -1366,14 +1466,14 @@ async fn run_datagram_loop(
             }
         };
 
-        let payload_fragment = &data[offset..offset + payload_size];
+        let payload_fragment = datagram_payload_fragment(&data, offset, payload_size)?;
 
         if let Err(e) = process_udp_packet(
             &connection,
             &client_proxy_selector,
             &resolver,
             &udp_session_map,
-            &mut fragments,
+            FragmentCacheAccess::Local(&mut fragments),
             assoc_id,
             packet_id,
             frag_total,
@@ -1471,4 +1571,117 @@ pub async fn start_tuic_server(
     }
 
     Ok(join_handles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn uni_stream_fragments_reassemble_with_shared_connection_cache() {
+        let fragment_cache: SharedFragmentCache = Arc::new(Mutex::new(new_fragment_cache()));
+        let remote_location = NetLocation::new(Address::Ipv4(Ipv4Addr::LOCALHOST), 5353);
+        let assoc_id = 7;
+        let packet_id = 42;
+
+        {
+            let mut fragments = fragment_cache.lock().await;
+            let result = record_udp_fragment(
+                &mut fragments,
+                assoc_id,
+                packet_id,
+                2,
+                0,
+                Some(remote_location.clone()),
+                b"hello ",
+            )
+            .unwrap();
+            assert!(result.is_none());
+            assert!(fragments.contains(&(assoc_id, packet_id)));
+        }
+
+        let result = {
+            let mut fragments = fragment_cache.lock().await;
+            record_udp_fragment(&mut fragments, assoc_id, packet_id, 2, 1, None, b"world")
+                .unwrap()
+                .unwrap()
+        };
+
+        assert_eq!(
+            result.remote_location.to_string(),
+            remote_location.to_string()
+        );
+        assert_eq!(result.payload, b"hello world".to_vec());
+
+        let fragments = fragment_cache.lock().await;
+        assert!(!fragments.contains(&(assoc_id, packet_id)));
+    }
+
+    #[tokio::test]
+    async fn fragment_cache_keys_packet_ids_by_association() {
+        let mut fragments = new_fragment_cache();
+        let first_location = NetLocation::new(Address::Ipv4(Ipv4Addr::LOCALHOST), 5353);
+        let second_location = NetLocation::new(Address::Ipv4(Ipv4Addr::LOCALHOST), 5354);
+        let packet_id = 42;
+
+        assert!(
+            record_udp_fragment(
+                &mut fragments,
+                7,
+                packet_id,
+                2,
+                0,
+                Some(first_location),
+                b"first ",
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            record_udp_fragment(
+                &mut fragments,
+                8,
+                packet_id,
+                2,
+                0,
+                Some(second_location),
+                b"second ",
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        assert!(fragments.contains(&(7, packet_id)));
+        assert!(fragments.contains(&(8, packet_id)));
+    }
+
+    #[test]
+    fn datagram_payload_guard_rejects_truncated_empty_address_payload() {
+        let data =
+            Bytes::from_static(&[5, COMMAND_TYPE_PACKET, 0, 1, 0, 2, 1, 0, 0x03, 0xe8, 0xff]);
+
+        assert!(datagram_payload_fragment(&data, 11, 1000).is_err());
+    }
+
+    #[test]
+    fn datagram_payload_guard_accepts_exact_payload_bounds() {
+        let data = Bytes::from_static(&[
+            5,
+            COMMAND_TYPE_PACKET,
+            0,
+            1,
+            0,
+            2,
+            1,
+            0,
+            0,
+            3,
+            0xff,
+            b'a',
+            b'b',
+            b'c',
+        ]);
+
+        assert_eq!(datagram_payload_fragment(&data, 11, 3).unwrap(), b"abc");
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,8 +19,14 @@ pub async fn write_all<T: AsyncWriteExt + Unpin>(
     let mut i = 0;
     let n = buf.len();
     while i < n {
-        let n = stream.write(&buf[i..]).await?;
-        i += n;
+        let written = stream.write(&buf[i..]).await?;
+        if written == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "write_all: write returned 0 bytes",
+            ));
+        }
+        i += written;
     }
     Ok(())
 }

--- a/src/vless/vless_util.rs
+++ b/src/vless/vless_util.rs
@@ -58,10 +58,22 @@ pub async fn parse_addons_from_reader<S: AsyncReadExt + Unpin>(
             ));
         }
         let (field_length, bytes_used) = read_varint(&addon_bytes[addon_cursor..])?;
+        let field_length = usize::try_from(field_length).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Addon field length does not fit in usize",
+            )
+        })?;
         addon_cursor += bytes_used;
 
         // Validate field_length is within bounds
-        if addon_cursor + field_length as usize > addon_bytes.len() {
+        let field_end = addon_cursor.checked_add(field_length).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Addon field length overflow",
+            )
+        })?;
+        if field_end > addon_bytes.len() {
             return Err(std::io::Error::other(format!(
                 "Field {} length {} exceeds remaining addon bytes (cursor: {}, total: {})",
                 field_number,
@@ -72,8 +84,8 @@ pub async fn parse_addons_from_reader<S: AsyncReadExt + Unpin>(
         }
 
         // Read field data
-        let field_data = &addon_bytes[addon_cursor..addon_cursor + field_length as usize];
-        addon_cursor += field_length as usize;
+        let field_data = &addon_bytes[addon_cursor..field_end];
+        addon_cursor = field_end;
 
         match field_number {
             1 => {
@@ -168,21 +180,21 @@ pub fn vision_flow_addon_data() -> &'static [u8] {
 }
 
 fn read_varint(data: &[u8]) -> std::io::Result<(u64, usize)> {
-    let mut cursor = 0usize;
     let mut length = 0u64;
-    loop {
-        let byte = data[cursor];
-        if (byte & 0b10000000) != 0 {
-            length = (length << 8) | ((byte ^ 0b10000000) as u64);
-        } else {
-            length = (length << 8) | (byte as u64);
-            return Ok((length, cursor + 1));
+
+    for (i, &byte) in data.iter().enumerate().take(10) {
+        let value = (byte & 0x7f) as u64;
+        length |= value << (i * 7);
+
+        if (byte & 0x80) == 0 {
+            return Ok((length, i + 1));
         }
-        if cursor == 7 || cursor == data.len() {
-            return Err(std::io::Error::other("Varint is too long"));
-        }
-        cursor += 1;
     }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "Varint is too long or truncated",
+    ))
 }
 
 /// Encode a flow string as protobuf addon data
@@ -211,4 +223,25 @@ fn encode_flow_addon(flow: &str) -> std::io::Result<Vec<u8>> {
     result.extend_from_slice(flow_bytes);
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_varint_decodes_protobuf_base128() {
+        assert_eq!(read_varint(&[0xac, 0x02]).unwrap(), (300, 2));
+    }
+
+    #[test]
+    fn read_varint_rejects_empty_and_truncated_input() {
+        assert!(read_varint(&[]).is_err());
+        assert!(read_varint(&[0x80]).is_err());
+    }
+
+    #[test]
+    fn read_varint_rejects_overlong_input() {
+        assert!(read_varint(&[0x80; 10]).is_err());
+    }
 }

--- a/src/vmess/nonce.rs
+++ b/src/vmess/nonce.rs
@@ -2,7 +2,7 @@ use aws_lc_rs::aead::{Nonce, NonceSequence};
 use aws_lc_rs::error::Unspecified;
 
 pub struct VmessNonceSequence {
-    count: u16,
+    count: u32,
     nonce: [u8; 12],
 }
 
@@ -16,12 +16,16 @@ impl VmessNonceSequence {
 
 impl NonceSequence for VmessNonceSequence {
     fn advance(&mut self) -> Result<Nonce, Unspecified> {
-        // the nonce is correct for the first packet since the first two
-        // bytes are already zero.
+        if self.count > u16::MAX as u32 {
+            return Err(Unspecified);
+        }
+
+        let count = self.count as u16;
+        self.nonce[0] = (count >> 8) as u8;
+        self.nonce[1] = (count & 0xff) as u8;
+
         let ret = Nonce::assume_unique_for_key(self.nonce);
-        self.count = self.count.wrapping_add(1);
-        self.nonce[0] = (self.count >> 8) as u8;
-        self.nonce[1] = (self.count & 0xff) as u8;
+        self.count += 1;
         Ok(ret)
     }
 }
@@ -116,21 +120,16 @@ mod tests {
     }
 
     #[test]
-    fn test_vmess_nonce_sequence_wrapping() {
-        // Test that counter wraps around at u16::MAX
+    fn test_vmess_nonce_sequence_rejects_counter_exhaustion() {
         let data = [0x00u8; 12];
         let mut seq = VmessNonceSequence::new(&data);
+        seq.count = u16::MAX as u32;
 
-        // Set internal state to just before wraparound
-        // We need to advance 65535 times, but that's slow
-        // Instead, just verify the wraparound behavior conceptually
-        // by checking a few iterations work correctly
-        for i in 0..10 {
-            let nonce = seq.advance().unwrap();
-            let nonce_bytes = nonce_to_bytes(nonce);
-            let counter = ((nonce_bytes[0] as u16) << 8) | (nonce_bytes[1] as u16);
-            assert_eq!(counter, i);
-        }
+        let nonce = seq.advance().unwrap();
+        let nonce_bytes = nonce_to_bytes(nonce);
+        assert_eq!(&nonce_bytes[0..2], &[0xff, 0xff]);
+
+        assert!(seq.advance().is_err());
     }
 
     #[test]

--- a/src/vmess/vmess_handler.rs
+++ b/src/vmess/vmess_handler.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, VecDeque};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -11,6 +12,7 @@ use aws_lc_rs::cipher::{
     EncryptingKey as CipherEncryptingKey, EncryptionContext, UnboundCipherKey,
 };
 use bytes::BytesMut;
+use parking_lot::Mutex;
 use rand::{Rng, RngExt};
 use sha3::Shake128;
 use sha3::digest::{ExtendableOutput, Update};
@@ -34,6 +36,9 @@ use crate::uuid_util::parse_uuid;
 use crate::xudp::XudpMessageStream;
 
 const TAG_LEN: usize = 16;
+const MIN_AEAD_HEADER_PAYLOAD_LEN: usize = 38;
+const VMESS_AUTH_ID_TIME_WINDOW_SECS: u64 = 120;
+const VMESS_AUTH_ID_REPLAY_CACHE_CAPACITY: usize = 4096;
 
 // VMess protocol command types
 const COMMAND_TCP: u8 = 1;
@@ -66,6 +71,7 @@ pub struct VmessTcpServerHandler {
     data_cipher: DataCipher,
     instruction_key: [u8; 16],
     aead_decrypting_key: CipherDecryptingKey,
+    auth_id_replay_cache: Mutex<AuthIdReplayCache>,
     udp_enabled: bool,
     proxy_selector: Arc<ClientProxySelector>,
     resolver: Arc<dyn Resolver>,
@@ -77,6 +83,59 @@ impl std::fmt::Debug for VmessTcpServerHandler {
             .field("data_cipher", &self.data_cipher)
             .field("udp_enabled", &self.udp_enabled)
             .finish_non_exhaustive()
+    }
+}
+
+struct AuthIdReplayCache {
+    seen: HashMap<[u8; 16], u64>,
+    order: VecDeque<[u8; 16]>,
+    capacity: usize,
+}
+
+impl AuthIdReplayCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            seen: HashMap::with_capacity(capacity),
+            order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn check_and_insert(
+        &mut self,
+        auth_id: [u8; 16],
+        timestamp_secs: u64,
+        current_time_secs: u64,
+        window_secs: u64,
+    ) -> bool {
+        self.prune_expired(current_time_secs, window_secs);
+
+        if self.seen.contains_key(&auth_id) {
+            return false;
+        }
+
+        while self.seen.len() >= self.capacity {
+            if let Some(evicted) = self.order.pop_front() {
+                self.seen.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+
+        self.seen.insert(auth_id, timestamp_secs);
+        self.order.push_back(auth_id);
+        true
+    }
+
+    fn prune_expired(&mut self, current_time_secs: u64, window_secs: u64) {
+        self.seen
+            .retain(|_, timestamp_secs| timestamp_secs.abs_diff(current_time_secs) <= window_secs);
+        self.order.retain(|auth_id| self.seen.contains_key(auth_id));
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.seen.len()
     }
 }
 
@@ -99,12 +158,22 @@ impl VmessTcpServerHandler {
         Self {
             data_cipher: cipher_name.into(),
             aead_decrypting_key,
+            auth_id_replay_cache: Mutex::new(AuthIdReplayCache::new(
+                VMESS_AUTH_ID_REPLAY_CACHE_CAPACITY,
+            )),
             instruction_key,
             udp_enabled,
             proxy_selector,
             resolver,
         }
     }
+}
+
+fn unix_epoch_elapsed_secs() -> u64 {
+    SystemTime::UNIX_EPOCH
+        .elapsed()
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[async_trait]
@@ -144,12 +213,23 @@ impl TcpServerHandler for VmessTcpServerHandler {
         }
 
         let time_secs = u64::from_be_bytes(aead_bytes[0..8].try_into().unwrap());
-        let current_time_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs();
+        let current_time_secs = unix_epoch_elapsed_secs();
         let time_delta = time_secs.abs_diff(current_time_secs);
-        if time_delta > 120 {
+        if time_delta > VMESS_AUTH_ID_TIME_WINDOW_SECS {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("Hash timestamp is too old ({time_secs} is {time_delta} seconds old)"),
+            ));
+        }
+        if !self.auth_id_replay_cache.lock().check_and_insert(
+            cert_hash,
+            time_secs,
+            current_time_secs,
+            VMESS_AUTH_ID_TIME_WINDOW_SECS,
+        ) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "AEAD auth ID replay detected",
             ));
         }
 
@@ -190,7 +270,14 @@ impl TcpServerHandler for VmessTcpServerHandler {
             ));
         }
 
-        let payload_length = u16::from_be_bytes(encrypted_payload_length[0..2].try_into().unwrap());
+        let payload_length =
+            u16::from_be_bytes(encrypted_payload_length[0..2].try_into().unwrap()) as usize;
+        if payload_length < MIN_AEAD_HEADER_PAYLOAD_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("VMess header payload too short: {payload_length}"),
+            ));
+        }
 
         let header_aead_key = super::sha2::kdf(
             &self.instruction_key,
@@ -202,8 +289,7 @@ impl TcpServerHandler for VmessTcpServerHandler {
             &[b"VMess Header AEAD Nonce", &cert_hash, &nonce],
         );
 
-        let mut encrypted_header =
-            allocate_vec(payload_length as usize + TAG_LEN).into_boxed_slice();
+        let mut encrypted_header = allocate_vec(payload_length + TAG_LEN).into_boxed_slice();
 
         stream_reader
             .read_slice_into(&mut server_stream, &mut encrypted_header)
@@ -225,6 +311,7 @@ impl TcpServerHandler for VmessTcpServerHandler {
         let mut header_reader = AeadHeaderReader {
             server_stream,
             decrypted_header: encrypted_header,
+            payload_len: payload_length,
             cursor: 0,
         };
 
@@ -687,14 +774,30 @@ impl TcpServerHandler for VmessTcpServerHandler {
 struct AeadHeaderReader {
     server_stream: Box<dyn AsyncStream>,
     decrypted_header: Box<[u8]>,
+    payload_len: usize,
     cursor: usize,
 }
 
 impl AeadHeaderReader {
     fn read_slice_into(&mut self, data: &mut [u8]) -> std::io::Result<()> {
         let len = data.len();
+        let end = self.cursor.checked_add(len).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "VMess AEAD header read offset overflow",
+            )
+        })?;
+        if end > self.payload_len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "VMess AEAD header truncated: need {} bytes, payload length is {}",
+                    end, self.payload_len
+                ),
+            ));
+        }
         data.copy_from_slice(&self.decrypted_header[self.cursor..self.cursor + len]);
-        self.cursor += len;
+        self.cursor = end;
         Ok(())
     }
 
@@ -738,6 +841,114 @@ impl VmessTcpClientHandler {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_stream::AsyncPing;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    struct TestStream;
+
+    impl AsyncRead for TestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncPing for TestStream {
+        fn supports_ping(&self) -> bool {
+            false
+        }
+
+        fn poll_write_ping(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<bool>> {
+            Poll::Ready(Ok(false))
+        }
+    }
+
+    impl AsyncStream for TestStream {}
+
+    #[test]
+    fn auth_id_replay_cache_rejects_duplicate_inside_window() {
+        let mut cache = AuthIdReplayCache::new(16);
+        let auth_id = [0x42u8; 16];
+
+        assert!(cache.check_and_insert(auth_id, 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+        assert!(!cache.check_and_insert(auth_id, 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+    }
+
+    #[test]
+    fn auth_id_replay_cache_prunes_entries_outside_window() {
+        let mut cache = AuthIdReplayCache::new(16);
+        let auth_id = [0x42u8; 16];
+
+        assert!(cache.check_and_insert(auth_id, 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+        assert!(cache.check_and_insert(
+            auth_id,
+            1_000,
+            1_000 + VMESS_AUTH_ID_TIME_WINDOW_SECS + 1,
+            VMESS_AUTH_ID_TIME_WINDOW_SECS,
+        ));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn auth_id_replay_cache_stays_bounded() {
+        let mut cache = AuthIdReplayCache::new(2);
+
+        assert!(cache.check_and_insert([1u8; 16], 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+        assert!(cache.check_and_insert([2u8; 16], 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+        assert!(cache.check_and_insert([3u8; 16], 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.check_and_insert([1u8; 16], 1_000, 1_000, VMESS_AUTH_ID_TIME_WINDOW_SECS));
+    }
+
+    #[test]
+    fn aead_header_reader_rejects_reads_past_payload_len() {
+        let mut reader = AeadHeaderReader {
+            server_stream: Box::new(TestStream),
+            decrypted_header: vec![0u8; 4 + TAG_LEN].into_boxed_slice(),
+            payload_len: 4,
+            cursor: 0,
+        };
+
+        let mut payload = [0u8; 4];
+        reader.read_slice_into(&mut payload).unwrap();
+
+        let mut extra = [0u8; 1];
+        let err = reader.read_slice_into(&mut extra).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("truncated"));
+    }
+}
+
 #[async_trait]
 impl TcpClientHandler for VmessTcpClientHandler {
     async fn setup_client_tcp_stream(
@@ -748,8 +959,9 @@ impl TcpClientHandler for VmessTcpClientHandler {
         // AEAD allows 120 second delta from the current time.
         // See authid.go in v2ray-core.
         let random_delta: u64 = rand::rng().random_range(0..241);
-        let time_secs: u64 =
-            SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() - 120u64 + random_delta;
+        let time_secs: u64 = unix_epoch_elapsed_secs()
+            .saturating_sub(VMESS_AUTH_ID_TIME_WINDOW_SECS)
+            .saturating_add(random_delta);
 
         let mut aead_bytes = [0u8; 16];
         let time_bytes = time_secs.to_be_bytes();
@@ -1031,8 +1243,9 @@ impl VmessTcpClientHandler {
 
         // AEAD allows 120 second delta from the current time.
         let random_delta: u64 = rand::rng().random_range(0..241);
-        let time_secs: u64 =
-            SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() - 120u64 + random_delta;
+        let time_secs: u64 = unix_epoch_elapsed_secs()
+            .saturating_sub(VMESS_AUTH_ID_TIME_WINDOW_SECS)
+            .saturating_add(random_delta);
 
         let mut aead_bytes = [0u8; 16];
         let time_bytes = time_secs.to_be_bytes();

--- a/src/vmess/vmess_stream.rs
+++ b/src/vmess/vmess_stream.rs
@@ -423,6 +423,16 @@ impl VmessStream {
                     ));
                 }
 
+                if padding_len > data_len.saturating_sub(self.tag_len) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "padding length ({}) exceeds encrypted data length ({}) minus tag length ({})",
+                            padding_len, data_len, self.tag_len
+                        ),
+                    ));
+                }
+
                 if self.tag_len > 0 && (data_len - padding_len) < self.tag_len {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -541,7 +551,7 @@ impl VmessStream {
         }
     }
 
-    fn create_write_packet(&mut self) -> bool {
+    fn create_write_packet(&mut self) -> std::io::Result<bool> {
         // If we have a pending prefix, prepend it to the write_packet buffer
         // so that the response header and first data packet go out together.
         if let Some(prefix) = self.pending_prefix_write.take() {
@@ -561,7 +571,7 @@ impl VmessStream {
 
         let max_metadata_size = 2 + max_padding_len + self.tag_len;
         if max_metadata_size >= write_packet_space {
-            return false;
+            return Ok(false);
         }
 
         // TODO: allow peeking so that we don't need to use MAX_PADDING_LEN above.
@@ -579,6 +589,9 @@ impl VmessStream {
 
         let write_packet_size: usize = data_size + padding_len + self.tag_len;
         assert!(write_packet_size + 2 <= self.write_packet.len());
+        if write_packet_size > u16::MAX as usize {
+            return Err(std::io::Error::other("VMess frame is too large"));
+        }
 
         let mut next_index = self.write_packet_end_offset;
 
@@ -592,13 +605,14 @@ impl VmessStream {
 
         match self.sealing_key {
             Some(ref mut sealing_key) => {
-                // TODO: don't unwrap here.
                 let tag = sealing_key
                     .seal_in_place_separate_tag(
                         Aad::empty(),
                         &mut self.write_packet[next_index..next_index + data_size],
                     )
-                    .unwrap();
+                    .map_err(|err| {
+                        std::io::Error::other(format!("failed to seal packet: {err}"))
+                    })?;
                 next_index += data_size;
 
                 self.write_packet[next_index..next_index + self.tag_len]
@@ -626,7 +640,12 @@ impl VmessStream {
             self.write_cache_size -= data_size;
         }
 
-        true
+        Ok(true)
+    }
+
+    fn create_write_packets_from_cache(&mut self) -> std::io::Result<()> {
+        while self.write_cache_size > 0 && self.create_write_packet()? {}
+        Ok(())
     }
 
     #[inline]
@@ -810,7 +829,9 @@ impl AsyncWrite for VmessStream {
         let mut cache_space = this.write_cache.len().saturating_sub(this.write_cache_size);
 
         if cache_space == 0 {
-            while this.write_cache_size > 0 && this.create_write_packet() {}
+            if let Err(e) = this.create_write_packets_from_cache() {
+                return Poll::Ready(Err(e));
+            }
             match this.do_write_packet(cx) {
                 Ok(all_written) => {
                     if !all_written {
@@ -823,7 +844,9 @@ impl AsyncWrite for VmessStream {
             }
             // now that we've written out all the packet data, create more packets to free up cache
             // space.
-            while this.write_cache_size > 0 && this.create_write_packet() {}
+            if let Err(e) = this.create_write_packets_from_cache() {
+                return Poll::Ready(Err(e));
+            }
             cache_space = this.write_cache.len().saturating_sub(this.write_cache_size);
             assert!(cache_space > 0);
         }
@@ -849,7 +872,9 @@ impl AsyncWrite for VmessStream {
 
         // Create a new write frame when flush is called when we don't have one.
         while this.write_cache_size > 0 || this.write_packet_end_offset > 0 {
-            while this.write_cache_size > 0 && this.create_write_packet() {}
+            if let Err(e) = this.create_write_packets_from_cache() {
+                return Poll::Ready(Err(e));
+            }
             match this.do_write_packet(cx) {
                 Ok(all_written) => {
                     if !all_written {
@@ -876,15 +901,23 @@ impl AsyncWrite for VmessStream {
                 ShutdownState::WriteRemainingData => {
                     if this.write_cache_size > 0 {
                         // create data packets.
-                        while this.write_cache_size > 0 && this.create_write_packet() {}
+                        if let Err(e) = this.create_write_packets_from_cache() {
+                            return Poll::Ready(Err(e));
+                        }
                     }
 
                     // create the empty packet.
                     // it's possible that the write_packet buffer contains the server response,
                     // and the empty shutdown packet together, ready to send off together.
-                    if this.write_cache_size == 0 && this.create_write_packet() {
-                        this.shutdown_state = ShutdownState::WriteEmptyPacket;
-                        continue;
+                    if this.write_cache_size == 0 {
+                        let created_empty_packet = match this.create_write_packet() {
+                            Ok(created) => created,
+                            Err(e) => return Poll::Ready(Err(e)),
+                        };
+                        if created_empty_packet {
+                            this.shutdown_state = ShutdownState::WriteEmptyPacket;
+                            continue;
+                        }
                     }
                     // if we cannot create the empty packet, the write_packet buffer must
                     // be too full, so flush and try again.
@@ -1091,6 +1124,9 @@ impl AsyncWriteMessage for VmessStream {
         }
 
         let write_packet_size = buf.len() + padding_len + this.tag_len;
+        if write_packet_size > u16::MAX as usize {
+            return Poll::Ready(Err(std::io::Error::other("VMess UDP frame is too large")));
+        }
         let write_packet_size = (write_packet_size as u16) ^ length_mask;
 
         this.write_packet[0] = (write_packet_size >> 8) as u8;
@@ -1107,6 +1143,11 @@ impl AsyncWriteMessage for VmessStream {
             this.write_packet[end_index..end_index + this.tag_len].copy_from_slice(tag.as_ref());
 
             end_index += this.tag_len;
+        }
+
+        if padding_len > 0 {
+            rand::rng().fill_bytes(&mut this.write_packet[end_index..end_index + padding_len]);
+            end_index += padding_len;
         }
 
         this.write_packet_end_offset = end_index;
@@ -1158,14 +1199,75 @@ impl AsyncMessageStream for VmessStream {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_stream::AsyncPing;
     use aws_lc_rs::aead::{CHACHA20_POLY1305, UnboundKey};
     use sha3::Shake128;
     use sha3::digest::{ExtendableOutput, Update};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    struct TestStream;
+
+    impl AsyncRead for TestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncPing for TestStream {
+        fn supports_ping(&self) -> bool {
+            false
+        }
+
+        fn poll_write_ping(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<bool>> {
+            Poll::Ready(Ok(false))
+        }
+    }
+
+    impl AsyncStream for TestStream {}
 
     fn create_shake128_reader(iv: &[u8]) -> VmessReader {
         let mut hasher = Shake128::default();
         hasher.update(iv);
         hasher.finalize_xof()
+    }
+
+    fn find_length_mask_with_padding() -> ([u8; 16], usize, u16) {
+        for seed in 0u8..=u8::MAX {
+            let iv = [seed; 16];
+            let mut mask = LengthMask::new(create_shake128_reader(&iv), true);
+            let (padding_len, length_mask) = mask.next_values();
+            if padding_len > 1 {
+                return (iv, padding_len, length_mask);
+            }
+        }
+        panic!("failed to find deterministic VMess length mask with padding");
     }
 
     #[test]
@@ -1367,6 +1469,93 @@ mod tests {
                 MAX_PADDING_LEN
             );
         }
+    }
+
+    #[test]
+    fn test_try_decrypt_rejects_padding_larger_than_data_len() {
+        let (iv, padding_len, length_mask) = find_length_mask_with_padding();
+        let data_len = padding_len - 1;
+        let masked_len = (data_len as u16) ^ length_mask;
+
+        let mut stream = VmessStream::new(
+            Box::new(TestStream),
+            false,
+            None,
+            Some(create_shake128_reader(&iv)),
+            None,
+            true,
+            None,
+            None,
+        );
+        stream.unprocessed_buf[..2].copy_from_slice(&masked_len.to_be_bytes());
+        stream.unprocessed_end_offset = 2;
+
+        let err = match stream.try_decrypt() {
+            Ok(_) => panic!("expected padding length validation error"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("padding length"));
+    }
+
+    #[test]
+    fn test_udp_write_message_appends_global_padding() {
+        let (iv, padding_len, length_mask) = find_length_mask_with_padding();
+        let mut stream = VmessStream::new(
+            Box::new(TestStream),
+            true,
+            None,
+            None,
+            Some(create_shake128_reader(&iv)),
+            true,
+            None,
+            None,
+        );
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match Pin::new(&mut stream).poll_write_message(&mut cx, b"ping") {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(err)) => panic!("unexpected write error: {err}"),
+            Poll::Pending => panic!("unexpected pending write"),
+        }
+
+        let masked_len = u16::from_be_bytes([stream.write_packet[0], stream.write_packet[1]]);
+        let data_len = (masked_len ^ length_mask) as usize;
+        assert_eq!(data_len, b"ping".len() + padding_len);
+        assert_eq!(
+            stream.write_packet_end_offset,
+            2 + b"ping".len() + padding_len
+        );
+        assert_eq!(&stream.write_packet[2..2 + b"ping".len()], b"ping");
+    }
+
+    #[test]
+    fn test_udp_write_message_rejects_u16_length_overflow() {
+        let (iv, padding_len, _) = find_length_mask_with_padding();
+        let mut stream = VmessStream::new(
+            Box::new(TestStream),
+            true,
+            None,
+            None,
+            Some(create_shake128_reader(&iv)),
+            true,
+            None,
+            None,
+        );
+        let payload = vec![0u8; u16::MAX as usize];
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let err = match Pin::new(&mut stream).poll_write_message(&mut cx, &payload) {
+            Poll::Ready(Ok(())) => panic!("expected length overflow error"),
+            Poll::Ready(Err(err)) => err,
+            Poll::Pending => panic!("unexpected pending write"),
+        };
+
+        assert!(padding_len > 0);
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("too large"));
     }
 
     #[test]

--- a/src/websocket/websocket_handler.rs
+++ b/src/websocket/websocket_handler.rs
@@ -100,7 +100,7 @@ impl TcpServerHandler for WebsocketTcpServerHandler {
             };
 
             let websocket_version_response_header =
-                match request_headers.get("sec-websocket_version") {
+                match request_headers.get("sec-websocket-version") {
                     Some(v) => format!("Sec-WebSocket-Version: {v}\r\n"),
                     None => "".to_string(),
                 };

--- a/src/websocket/websocket_stream.rs
+++ b/src/websocket/websocket_stream.rs
@@ -34,6 +34,10 @@ pub struct WebsocketStream {
     ping_data: Box<[u8]>,
     ping_data_size: usize,
     pending_write_pong: bool,
+    close_data: Box<[u8]>,
+    close_data_size: usize,
+    pending_write_close: bool,
+    received_close: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -43,6 +47,7 @@ enum ReadState {
     ReadMask,
     ReadBinaryContent,
     ReadPingContent,
+    ReadCloseContent,
     SkipContent,
 }
 
@@ -81,7 +86,8 @@ impl WebsocketStream {
         let mut unprocessed_buf = allocate_vec(16384).into_boxed_slice();
         let mut unprocessed_end_offset = 0;
         let write_frame = allocate_vec(32768).into_boxed_slice();
-        let ping_data = allocate_vec(80).into_boxed_slice();
+        let ping_data = allocate_vec(125).into_boxed_slice();
+        let close_data = allocate_vec(125).into_boxed_slice();
 
         let pending_initial_data = if !unprocessed_data.is_empty() {
             unprocessed_buf[0..unprocessed_data.len()].copy_from_slice(unprocessed_data);
@@ -111,6 +117,10 @@ impl WebsocketStream {
             ping_data,
             ping_data_size: 0,
             pending_write_pong: false,
+            close_data,
+            close_data_size: 0,
+            pending_write_close: false,
+            received_close: false,
         }
     }
 
@@ -268,7 +278,7 @@ impl WebsocketStream {
                     self.pending_write_pong = true;
                     self.step_init(cx, buf)
                 } else {
-                    if self.read_frame_length as usize > self.ping_data.len() {
+                    if self.read_frame_length > self.ping_data.len() as u64 {
                         return Err(std::io::Error::other(format!(
                             "cannot handle ping data length ({})",
                             self.read_frame_length
@@ -291,18 +301,41 @@ impl WebsocketStream {
                 // ping, ie. we could send 5 pings and only 1 pong response arrives.
                 // So it's hard to keep track of if a pong is "valid".
                 // https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.3
-
-                // Our ping frames are always with zero data.
-                if self.read_frame_length != 0 {
+                if self.read_frame_length > 125 {
                     return Err(std::io::Error::other(format!(
-                        "unexpected pong data length ({})",
+                        "invalid pong data length ({})",
                         self.read_frame_length
                     )));
                 }
-                self.read_state = ReadState::Init;
-                self.step_init(cx, buf)
+                if self.read_frame_length == 0 {
+                    self.read_state = ReadState::Init;
+                    self.step_init(cx, buf)
+                } else {
+                    self.read_state = ReadState::SkipContent;
+                    self.step_skip_content(cx, buf)
+                }
             }
-            // TODO: handle close frames
+            OpCode::Close => {
+                if self.read_frame_length > self.close_data.len() as u64 {
+                    return Err(std::io::Error::other(format!(
+                        "cannot handle close data length ({})",
+                        self.read_frame_length
+                    )));
+                }
+
+                self.close_data_size = 0;
+                self.pending_write_pong = false;
+                if self.read_frame_length == 0 {
+                    self.read_state = ReadState::Init;
+                    self.pending_write_close = true;
+                    self.received_close = true;
+                    Ok(())
+                } else {
+                    self.pending_write_close = false;
+                    self.read_state = ReadState::ReadCloseContent;
+                    self.step_read_close_content(cx, buf)
+                }
+            }
             _ => {
                 warn!("Ignoring unknown frame type: {:?}", self.read_frame_opcode);
                 if self.read_frame_length == 0 {
@@ -336,6 +369,7 @@ impl WebsocketStream {
         }
 
         self.read_state = ReadState::Init;
+        self.read_frame_mask_offset = 0;
         self.step_init(cx, buf)
     }
 
@@ -378,6 +412,54 @@ impl WebsocketStream {
             // to flush unless poll_write or poll_write_ping is called anyway.
             self.pending_write_pong = true;
             return self.step_init(cx, buf);
+        }
+
+        Ok(())
+    }
+
+    fn step_read_close_content(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> std::io::Result<()> {
+        let unprocessed_len = self.unprocessed_end_offset - self.unprocessed_start_offset;
+        let read_amount = std::cmp::min(unprocessed_len, self.read_frame_length as usize);
+        if read_amount == 0 {
+            return Ok(());
+        }
+
+        let content_bytes = &mut self.unprocessed_buf
+            [self.unprocessed_start_offset..self.unprocessed_start_offset + read_amount];
+        if self.read_frame_masked {
+            let iter = content_bytes.iter_mut().zip(
+                self.read_frame_mask
+                    .iter()
+                    .cycle()
+                    .skip(self.read_frame_mask_offset),
+            );
+            for (byte, &key) in iter {
+                *byte ^= key
+            }
+            self.read_frame_mask_offset = (self.read_frame_mask_offset + read_amount) % 4;
+        }
+
+        self.close_data[self.close_data_size..self.close_data_size + read_amount]
+            .copy_from_slice(content_bytes);
+        self.close_data_size += read_amount;
+
+        self.unprocessed_start_offset += read_amount;
+        if self.unprocessed_start_offset == self.unprocessed_end_offset {
+            self.unprocessed_start_offset = 0;
+            self.unprocessed_end_offset = 0;
+        }
+
+        self.read_frame_length -= read_amount as u64;
+
+        if self.read_frame_length == 0 {
+            self.read_frame_mask_offset = 0;
+            self.read_state = ReadState::Init;
+            self.pending_write_close = true;
+            self.received_close = true;
         }
 
         Ok(())
@@ -493,6 +575,45 @@ impl WebsocketStream {
         true
     }
 
+    fn pack_write_close_frame(&mut self) -> bool {
+        let available_space = self.write_frame.len() - self.write_frame_end_offset;
+
+        // up to 14 bytes for header and mask
+        if available_space < self.close_data_size + 14 {
+            return false;
+        }
+
+        let written = pack_frame(
+            0x08,
+            self.is_client,
+            &self.close_data[0..self.close_data_size],
+            &mut self.write_frame[self.write_frame_end_offset..],
+        );
+        self.write_frame_end_offset += written;
+
+        true
+    }
+
+    fn pack_pending_control_frames(&mut self) -> bool {
+        if self.pending_write_close {
+            if self.pack_write_close_frame() {
+                self.pending_write_close = false;
+            } else {
+                return false;
+            }
+        }
+
+        if self.pending_write_pong {
+            if self.pack_write_pong_frame() {
+                self.pending_write_pong = false;
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
+
     fn pack_write_frame(&mut self, input: &[u8]) -> usize {
         let available_space = self.write_frame.len() - self.write_frame_end_offset;
 
@@ -571,6 +692,10 @@ impl AsyncRead for WebsocketStream {
     ) -> std::task::Poll<std::io::Result<()>> {
         let this = self.get_mut();
 
+        if this.received_close {
+            return Poll::Ready(Ok(()));
+        }
+
         // If there is unprocessed data and we are reading content, it must be because there
         // is data still to be read, but the passed in `buf` from the previous iteration
         // didn't have enough space to read it all.
@@ -626,10 +751,15 @@ impl AsyncRead for WebsocketStream {
                 ReadState::SkipContent => this.step_skip_content(cx, buf),
                 ReadState::ReadBinaryContent => this.step_read_binary_content(cx, buf),
                 ReadState::ReadPingContent => this.step_read_ping_content(cx, buf),
+                ReadState::ReadCloseContent => this.step_read_close_content(cx, buf),
             };
 
             if read_result.is_err() {
                 return Poll::Ready(read_result);
+            }
+
+            if this.received_close {
+                return Poll::Ready(Ok(()));
             }
 
             if !buf.filled().is_empty() {
@@ -647,20 +777,13 @@ impl AsyncWrite for WebsocketStream {
     ) -> std::task::Poll<std::io::Result<usize>> {
         let this = self.get_mut();
 
-        if this.pending_write_pong {
-            if this.pack_write_pong_frame() {
-                this.pending_write_pong = false;
-            } else {
-                // Write and try to make space in the write frame,
-                // then try again.
-                if let Err(e) = this.do_write_frame(cx) {
-                    return Poll::Ready(Err(e));
-                }
-                if this.pack_write_pong_frame() {
-                    this.pending_write_pong = false;
-                } else {
-                    return Poll::Pending;
-                }
+        while !this.pack_pending_control_frames() {
+            // Write and try to make space in the write frame, then try again.
+            if let Err(e) = this.do_write_frame(cx) {
+                return Poll::Ready(Err(e));
+            }
+            if this.write_frame_end_offset > 0 {
+                return Poll::Pending;
             }
         }
 
@@ -696,6 +819,19 @@ impl AsyncWrite for WebsocketStream {
     ) -> std::task::Poll<std::io::Result<()>> {
         let this = self.get_mut();
 
+        while !this.pack_pending_control_frames() {
+            match this.do_write_frame(cx) {
+                Ok(()) => {
+                    if this.write_frame_end_offset > 0 {
+                        return Poll::Pending;
+                    }
+                }
+                Err(e) => {
+                    return Poll::Ready(Err(e));
+                }
+            }
+        }
+
         if this.write_frame_end_offset == 0 {
             return Pin::new(&mut this.stream).poll_flush(cx);
         }
@@ -719,10 +855,39 @@ impl AsyncWrite for WebsocketStream {
     }
 
     fn poll_shutdown(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        Pin::new(&mut self.stream).poll_shutdown(cx)
+        let this = self.get_mut();
+
+        while !this.pack_pending_control_frames() {
+            match this.do_write_frame(cx) {
+                Ok(()) => {
+                    if this.write_frame_end_offset > 0 {
+                        return Poll::Pending;
+                    }
+                }
+                Err(e) => {
+                    return Poll::Ready(Err(e));
+                }
+            }
+        }
+
+        while this.write_frame_end_offset > 0 {
+            match this.do_write_frame(cx) {
+                Ok(()) => {
+                    if this.write_frame_end_offset > 0 {
+                        return Poll::Pending;
+                    }
+                }
+                Err(e) => {
+                    return Poll::Ready(Err(e));
+                }
+            }
+            ready!(Pin::new(&mut this.stream).poll_flush(cx))?;
+        }
+
+        Pin::new(&mut this.stream).poll_shutdown(cx)
     }
 }
 
@@ -734,15 +899,14 @@ impl AsyncPing for WebsocketStream {
     fn poll_write_ping(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<bool>> {
         let this = self.get_mut();
 
-        if this.pending_write_pong {
-            if this.pack_write_pong_frame() {
-                this.pending_write_pong = false;
+        if this.pending_write_close || this.pending_write_pong {
+            if this.pack_pending_control_frames() {
                 return Poll::Ready(Ok(true));
             } else {
-                // If pack_write_pong_frame returns false, it means that there's not enough space
-                // for the pong frame at the moment - but that also means:
+                // If packing returns false, it means that there's not enough space
+                // for the control frame at the moment - but that also means:
                 // 1) we have lots of data to write out
-                // 2) a future check of pending_write_pong will still result in a pong being
+                // 2) a future check of pending control frames will still result in one being
                 // written.
                 // This isn't a case where we are pending a write - so don't return Poll::Pending,
                 // simply return that no data has been written.
@@ -824,4 +988,132 @@ fn pack_frame(opcode: u8, use_mask: bool, input: &[u8], output: &mut [u8]) -> us
     }
 
     offset + input_len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::task::noop_waker;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct TestStream {
+        written: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl AsyncRead for TestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.written.lock().unwrap().extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncPing for TestStream {
+        fn supports_ping(&self) -> bool {
+            false
+        }
+
+        fn poll_write_ping(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<bool>> {
+            Poll::Ready(Ok(false))
+        }
+    }
+
+    impl AsyncStream for TestStream {}
+
+    #[test]
+    fn non_empty_pong_payload_is_skipped() {
+        let stream = TestStream::default();
+        let frame = [0x8a, 0x03, b'a', b'b', b'c'];
+        let mut websocket =
+            WebsocketStream::new(Box::new(stream), false, WebsocketPingType::Disabled, &frame);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut output = [0u8; 8];
+        let mut read_buf = ReadBuf::new(&mut output);
+
+        let result = Pin::new(&mut websocket).poll_read(&mut cx, &mut read_buf);
+
+        assert!(matches!(result, Poll::Pending));
+        assert!(read_buf.filled().is_empty());
+        assert_eq!(websocket.read_state, ReadState::Init);
+    }
+
+    #[test]
+    fn close_frame_is_echoed_with_payload() {
+        let stream = TestStream::default();
+        let written = stream.written.clone();
+        let close_frame = [0x88, 0x02, 0x03, 0xe8];
+        let mut websocket = WebsocketStream::new(
+            Box::new(stream),
+            false,
+            WebsocketPingType::Disabled,
+            &close_frame,
+        );
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut output = [0u8; 8];
+        let mut read_buf = ReadBuf::new(&mut output);
+
+        let read_result = Pin::new(&mut websocket).poll_read(&mut cx, &mut read_buf);
+        assert!(matches!(read_result, Poll::Ready(Ok(()))));
+        assert!(websocket.pending_write_close);
+        assert!(websocket.received_close);
+
+        let flush_result = Pin::new(&mut websocket).poll_flush(&mut cx);
+        assert!(matches!(flush_result, Poll::Ready(Ok(()))));
+
+        assert_eq!(&*written.lock().unwrap(), &close_frame);
+    }
+
+    #[test]
+    fn max_size_ping_is_echoed_as_pong() {
+        let stream = TestStream::default();
+        let written = stream.written.clone();
+        let mut frame = Vec::with_capacity(127);
+        frame.extend_from_slice(&[0x89, 125]);
+        frame.extend(std::iter::repeat_n(0x42, 125));
+        let mut websocket =
+            WebsocketStream::new(Box::new(stream), false, WebsocketPingType::Disabled, &frame);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut output = [0u8; 8];
+        let mut read_buf = ReadBuf::new(&mut output);
+
+        let read_result = Pin::new(&mut websocket).poll_read(&mut cx, &mut read_buf);
+        assert!(matches!(read_result, Poll::Ready(Ok(())) | Poll::Pending));
+        assert!(websocket.pending_write_pong);
+
+        let flush_result = Pin::new(&mut websocket).poll_flush(&mut cx);
+        assert!(matches!(flush_result, Poll::Ready(Ok(()))));
+
+        let written = written.lock().unwrap();
+        assert_eq!(written[0], 0x8a);
+        assert_eq!(written[1], 125);
+        assert_eq!(&written[2..], &frame[2..]);
+    }
 }

--- a/src/xudp/message_stream.rs
+++ b/src/xudp/message_stream.rs
@@ -20,6 +20,8 @@ use crate::resolver::{NativeResolver, ResolverCache};
 
 use super::frame::{FrameMetadata, FrameOption, SessionStatus, TargetNetwork};
 
+const MAX_XUDP_SESSIONS: usize = 1024;
+
 pub struct XudpMessageStream {
     /// Underlying byte stream (VLESS VisionStream, VMess stream, or any TLS stream) that reads/writes raw XUDP frame bytes
     inner_stream: Box<dyn AsyncStream>,
@@ -93,8 +95,48 @@ impl XudpMessageStream {
     }
 
     /// Allocate new session ID
-    fn allocate_session_id(&mut self) -> u16 {
-        loop {
+    fn active_session_count(&self) -> usize {
+        self.session_to_destination
+            .len()
+            .max(self.session_to_original_destination.len())
+            .max(self.destination_to_session.len())
+    }
+
+    fn ensure_session_capacity_for(&self, session_id: u16) -> std::io::Result<()> {
+        if self.session_to_destination.contains_key(&session_id)
+            || self
+                .session_to_original_destination
+                .contains_key(&session_id)
+        {
+            return Ok(());
+        }
+
+        if self.active_session_count() >= MAX_XUDP_SESSIONS {
+            return Err(std::io::Error::other("XUDP session table full"));
+        }
+
+        Ok(())
+    }
+
+    fn upsert_session_mapping(
+        &mut self,
+        session_id: u16,
+        target: NetLocation,
+    ) -> std::io::Result<()> {
+        self.ensure_session_capacity_for(session_id)?;
+        self.session_to_destination
+            .insert(session_id, target.clone());
+        self.session_to_original_destination
+            .insert(session_id, target);
+        Ok(())
+    }
+
+    fn allocate_session_id(&mut self) -> std::io::Result<u16> {
+        if self.active_session_count() >= MAX_XUDP_SESSIONS {
+            return Err(std::io::Error::other("XUDP session table full"));
+        }
+
+        for _ in 0..u16::MAX {
             let id = self.next_session_id;
             self.next_session_id = self.next_session_id.wrapping_add(1);
             if self.next_session_id == 0 {
@@ -103,9 +145,11 @@ impl XudpMessageStream {
 
             // Check if ID is already in use (unlikely with u16 space)
             if !self.session_to_destination.contains_key(&id) {
-                return id;
+                return Ok(id);
             }
         }
+
+        Err(std::io::Error::other("XUDP session ID space exhausted"))
     }
 
     /// Get or create session ID for destination, preserving original address
@@ -115,16 +159,16 @@ impl XudpMessageStream {
         &mut self,
         resolved_destination: &NetLocation,
         original_destination: &NetLocation,
-    ) -> (u16, bool) {
+    ) -> std::io::Result<(u16, bool)> {
         if let Some(&session_id) = self.destination_to_session.get(resolved_destination) {
             log::debug!(
                 "[XUDP] Found existing session {} for destination {}",
                 session_id,
                 resolved_destination
             );
-            (session_id, false) // Existing session
+            Ok((session_id, false)) // Existing session
         } else {
-            let session_id = self.allocate_session_id();
+            let session_id = self.allocate_session_id()?;
             log::debug!(
                 "[XUDP] Creating NEW session {} for resolved dest {} (original: {})",
                 session_id,
@@ -142,7 +186,7 @@ impl XudpMessageStream {
                 "[XUDP] Session maps updated. Total sessions: {}",
                 self.destination_to_session.len()
             );
-            (session_id, true) // New session
+            Ok((session_id, true)) // New session
         }
     }
 
@@ -162,42 +206,107 @@ impl XudpMessageStream {
             self.read_buffer.len()
         );
 
-        // First, peek at the buffer to determine total frame size WITHOUT consuming anything.
-        // We need to check: metadata_len (2 bytes) + metadata + data_len (2 bytes) + data
+        loop {
+            // First, peek at the buffer to determine total frame size WITHOUT consuming anything.
+            // We need to check: metadata_len (2 bytes) + metadata + data_len (2 bytes) + data
 
-        // Need at least 2 bytes for metadata length
-        if self.read_buffer.len() < 2 {
-            log::debug!("[XUDP READ] Buffer too short for metadata length field");
-            return Ok(None);
-        }
+            // Need at least 2 bytes for metadata length
+            if self.read_buffer.len() < 2 {
+                log::debug!("[XUDP READ] Buffer too short for metadata length field");
+                return Ok(None);
+            }
 
-        let metadata_len = u16::from_be_bytes([self.read_buffer[0], self.read_buffer[1]]) as usize;
+            let metadata_len =
+                u16::from_be_bytes([self.read_buffer[0], self.read_buffer[1]]) as usize;
 
-        // Check if we have complete metadata
-        if self.read_buffer.len() < 2 + metadata_len {
-            log::debug!("[XUDP READ] Buffer too short for complete metadata");
-            return Ok(None);
-        }
+            // Check if we have complete metadata
+            if self.read_buffer.len() < 2 + metadata_len {
+                log::debug!("[XUDP READ] Buffer too short for complete metadata");
+                return Ok(None);
+            }
 
-        // Peek at metadata to check if frame has data
-        if metadata_len < 4 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("metadata too short: {}", metadata_len),
-            ));
-        }
+            // Peek at metadata to check if frame has data
+            if metadata_len < 4 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("metadata too short: {}", metadata_len),
+                ));
+            }
 
-        // Peek at status and option bytes (at offset 2 + 2 + 1 = 5 for status, 6 for option)
-        let status_byte = self.read_buffer[2 + 2]; // Skip metadata_len(2) + session_id(2)
-        let option_byte = self.read_buffer[2 + 3]; // Skip metadata_len(2) + session_id(2) + status(1)
+            // Peek at status and option bytes (at offset 2 + 2 + 1 = 5 for status, 6 for option)
+            let status_byte = self.read_buffer[2 + 2]; // Skip metadata_len(2) + session_id(2)
+            let option_byte = self.read_buffer[2 + 3]; // Skip metadata_len(2) + session_id(2) + status(1)
 
-        let has_data = (option_byte & 0x01) != 0; // FrameOption::DATA = 0x01
-        let is_end = status_byte == 0x03; // SessionStatus::End
-        let is_keepalive = status_byte == 0x04; // SessionStatus::KeepAlive
+            let has_data = (option_byte & 0x01) != 0; // FrameOption::DATA = 0x01
+            let is_end = status_byte == 0x03; // SessionStatus::End
+            let is_keepalive = status_byte == 0x04; // SessionStatus::KeepAlive
 
-        // For End or KeepAlive frames, or frames without data, we only need the metadata
-        if is_end || is_keepalive || !has_data {
-            // We have enough data to decode this frame - proceed with actual decode
+            // For End or KeepAlive frames, or frames without data, we only need the metadata
+            if is_end || is_keepalive || !has_data {
+                // We have enough data to decode this frame - proceed with actual decode
+                let metadata = FrameMetadata::decode(&mut self.read_buffer)?
+                    .expect("metadata decode should succeed after length check");
+
+                log::debug!(
+                    "[XUDP READ] Decoded frame: session_id={}, status={:?}, has_data={}, target={:?}, network={:?}",
+                    metadata.session_id,
+                    metadata.status,
+                    metadata.option.has_data(),
+                    metadata.target,
+                    metadata.network
+                );
+
+                // Handle session mappings
+                if let Some(ref target) = metadata.target
+                    && metadata.status != SessionStatus::End
+                {
+                    log::debug!(
+                        "[XUDP READ] Updating session {} mapping to target {}",
+                        metadata.session_id,
+                        target
+                    );
+                    self.upsert_session_mapping(metadata.session_id, target.clone())?;
+                }
+
+                if metadata.status == SessionStatus::End {
+                    if let Some(destination) =
+                        self.session_to_destination.remove(&metadata.session_id)
+                    {
+                        self.destination_to_session.remove(&destination);
+                    }
+                    self.session_to_original_destination
+                        .remove(&metadata.session_id);
+                    continue;
+                }
+
+                // No data, try to decode next frame
+                continue;
+            }
+
+            // Frame has data - check if we have the data length and data
+            let data_len_offset = 2 + metadata_len;
+            if self.read_buffer.len() < data_len_offset + 2 {
+                log::debug!("[XUDP READ] Buffer too short for data length field");
+                return Ok(None);
+            }
+
+            let data_len = u16::from_be_bytes([
+                self.read_buffer[data_len_offset],
+                self.read_buffer[data_len_offset + 1],
+            ]) as usize;
+
+            // Check if we have all the data
+            let total_frame_len = data_len_offset + 2 + data_len;
+            if self.read_buffer.len() < total_frame_len {
+                log::debug!(
+                    "[XUDP READ] Buffer too short for complete frame: have {}, need {}",
+                    self.read_buffer.len(),
+                    total_frame_len
+                );
+                return Ok(None);
+            }
+
+            // Now we know we have a complete frame - consume it all
             let metadata = FrameMetadata::decode(&mut self.read_buffer)?
                 .expect("metadata decode should succeed after length check");
 
@@ -210,136 +319,71 @@ impl XudpMessageStream {
                 metadata.network
             );
 
-            // Handle session mappings
+            // Check for TCP destination - we don't support TCP over XUDP
+            if let Some(TargetNetwork::Tcp) = metadata.network {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "XUDP with TCP destinations is not supported. Only UDP destinations are supported.",
+                ));
+            }
+
+            // Check for ERROR option bit - remote side is signaling an error
+            if metadata.option.has_error() {
+                log::error!(
+                    "[XUDP READ] Received frame with ERROR option set for session {}",
+                    metadata.session_id
+                );
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "XUDP session closed by remote with error",
+                ));
+            }
+
+            // Store/update session mapping for session_id → destination
             if let Some(ref target) = metadata.target {
                 log::debug!(
                     "[XUDP READ] Updating session {} mapping to target {}",
                     metadata.session_id,
                     target
                 );
+                self.upsert_session_mapping(metadata.session_id, target.clone())?;
+            }
+
+            // Consume data length (already verified we have it)
+            self.read_buffer.advance(2);
+
+            if data_len == 0 {
+                // Empty data, try to decode next frame
+                continue;
+            }
+
+            // Extract data (already verified we have it)
+            let data = self.read_buffer[..data_len].to_vec();
+            self.read_buffer.advance(data_len);
+
+            // Determine destination
+            let destination = if let Some(ref target) = metadata.target {
+                target.clone()
+            } else {
+                // Look up in session map
                 self.session_to_destination
-                    .insert(metadata.session_id, target.clone());
-                self.session_to_original_destination
-                    .insert(metadata.session_id, target.clone());
-            }
+                    .get(&metadata.session_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("unknown session ID: {}", metadata.session_id),
+                        )
+                    })?
+            };
 
-            if metadata.status == SessionStatus::End {
-                if let Some(destination) = self.session_to_destination.remove(&metadata.session_id)
-                {
-                    self.destination_to_session.remove(&destination);
-                }
-                self.session_to_original_destination
-                    .remove(&metadata.session_id);
-                return self.try_decode_one_frame();
-            }
-
-            // No data, try to decode next frame
-            return self.try_decode_one_frame();
-        }
-
-        // Frame has data - check if we have the data length and data
-        let data_len_offset = 2 + metadata_len;
-        if self.read_buffer.len() < data_len_offset + 2 {
-            log::debug!("[XUDP READ] Buffer too short for data length field");
-            return Ok(None);
-        }
-
-        let data_len = u16::from_be_bytes([
-            self.read_buffer[data_len_offset],
-            self.read_buffer[data_len_offset + 1],
-        ]) as usize;
-
-        // Check if we have all the data
-        let total_frame_len = data_len_offset + 2 + data_len;
-        if self.read_buffer.len() < total_frame_len {
             log::debug!(
-                "[XUDP READ] Buffer too short for complete frame: have {}, need {}",
-                self.read_buffer.len(),
-                total_frame_len
+                "[XUDP READ] Decoded complete frame with {} bytes for destination {}",
+                data.len(),
+                destination
             );
-            return Ok(None);
+            return Ok(Some((data, destination)));
         }
-
-        // Now we know we have a complete frame - consume it all
-        let metadata = FrameMetadata::decode(&mut self.read_buffer)?
-            .expect("metadata decode should succeed after length check");
-
-        log::debug!(
-            "[XUDP READ] Decoded frame: session_id={}, status={:?}, has_data={}, target={:?}, network={:?}",
-            metadata.session_id,
-            metadata.status,
-            metadata.option.has_data(),
-            metadata.target,
-            metadata.network
-        );
-
-        // Check for TCP destination - we don't support TCP over XUDP
-        if let Some(TargetNetwork::Tcp) = metadata.network {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "XUDP with TCP destinations is not supported. Only UDP destinations are supported.",
-            ));
-        }
-
-        // Check for ERROR option bit - remote side is signaling an error
-        if metadata.option.has_error() {
-            log::error!(
-                "[XUDP READ] Received frame with ERROR option set for session {}",
-                metadata.session_id
-            );
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionReset,
-                "XUDP session closed by remote with error",
-            ));
-        }
-
-        // Store/update session mapping for session_id → destination
-        if let Some(ref target) = metadata.target {
-            log::debug!(
-                "[XUDP READ] Updating session {} mapping to target {}",
-                metadata.session_id,
-                target
-            );
-            self.session_to_destination
-                .insert(metadata.session_id, target.clone());
-            self.session_to_original_destination
-                .insert(metadata.session_id, target.clone());
-        }
-
-        // Consume data length (already verified we have it)
-        self.read_buffer.advance(2);
-
-        if data_len == 0 {
-            // Empty data, try to decode next frame
-            return self.try_decode_one_frame();
-        }
-
-        // Extract data (already verified we have it)
-        let data = self.read_buffer[..data_len].to_vec();
-        self.read_buffer.advance(data_len);
-
-        // Determine destination
-        let destination = if let Some(ref target) = metadata.target {
-            target.clone()
-        } else {
-            // Look up in session map
-            self.session_to_destination
-                .get(&metadata.session_id)
-                .cloned()
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("unknown session ID: {}", metadata.session_id),
-                    )
-                })?
-        };
-
-        log::debug!(
-            "[XUDP READ] Decoded complete frame with {} bytes for destination {}",
-            data.len(),
-            destination
-        );
-        Ok(Some((data, destination)))
     }
 }
 
@@ -424,7 +468,10 @@ impl AsyncReadSessionMessage for XudpMessageStream {
 
             // Find session ID for resolved destination, preserving original
             let (session_id, _is_new) =
-                this.get_or_create_session(&resolved_destination, &original_destination);
+                match this.get_or_create_session(&resolved_destination, &original_destination) {
+                    Ok(session) => session,
+                    Err(e) => return Poll::Ready(Err(e)),
+                };
 
             // Convert to SocketAddr for return
             let socket_addr = futures::ready!(
@@ -478,7 +525,10 @@ impl AsyncReadSessionMessage for XudpMessageStream {
 
                     // Get or create session, preserving original destination (may be hostname)
                     let (session_id, _is_new) =
-                        this.get_or_create_session(&resolved_destination, &destination);
+                        match this.get_or_create_session(&resolved_destination, &destination) {
+                            Ok(session) => session,
+                            Err(e) => return Poll::Ready(Err(e)),
+                        };
                     log::debug!(
                         "[XUDP SESSION READ] Session {} mapped to {}",
                         session_id,
@@ -604,6 +654,9 @@ impl AsyncWriteSessionMessage for XudpMessageStream {
                 session_id,
                 target_location
             );
+            if let Err(e) = self.ensure_session_capacity_for(session_id) {
+                return Poll::Ready(Err(e));
+            }
             // Store the mapping for potential future writes with same session_id
             self.session_to_original_destination
                 .insert(session_id, target_location.clone());
@@ -664,3 +717,146 @@ impl AsyncWriteSessionMessage for XudpMessageStream {
 }
 
 impl AsyncSessionMessageStream for XudpMessageStream {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestStream;
+
+    impl AsyncRead for TestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for TestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncPing for TestStream {
+        fn supports_ping(&self) -> bool {
+            false
+        }
+
+        fn poll_write_ping(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<bool>> {
+            Poll::Ready(Ok(false))
+        }
+    }
+
+    impl AsyncStream for TestStream {}
+
+    fn fill_session_table(stream: &mut XudpMessageStream) {
+        for session_id in 1..=MAX_XUDP_SESSIONS as u16 {
+            let destination = NetLocation::new(
+                Address::Ipv4(std::net::Ipv4Addr::new(
+                    127,
+                    0,
+                    (session_id >> 8) as u8,
+                    (session_id & 0xff) as u8,
+                )),
+                session_id,
+            );
+            stream
+                .destination_to_session
+                .insert(destination.clone(), session_id);
+            stream
+                .session_to_destination
+                .insert(session_id, destination.clone());
+            stream
+                .session_to_original_destination
+                .insert(session_id, destination);
+        }
+    }
+
+    #[test]
+    fn get_or_create_session_errors_when_session_table_full() {
+        let mut stream = XudpMessageStream::new(Box::new(TestStream));
+        fill_session_table(&mut stream);
+
+        let destination = NetLocation::new(Address::Ipv4(std::net::Ipv4Addr::LOCALHOST), 9_999);
+        let err = stream
+            .get_or_create_session(&destination, &destination)
+            .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("session table full"));
+    }
+
+    #[test]
+    fn rejects_new_remote_session_mapping_when_session_table_full() {
+        let mut stream = XudpMessageStream::new(Box::new(TestStream));
+        fill_session_table(&mut stream);
+
+        let target = NetLocation::new(Address::Ipv4(std::net::Ipv4Addr::LOCALHOST), 53);
+        let frame = FrameMetadata {
+            session_id: 60_000,
+            status: SessionStatus::New,
+            option: FrameOption::new(),
+            target: Some(target),
+            network: Some(TargetNetwork::Udp),
+        };
+        let mut encoded = BytesMut::new();
+        frame.encode(&mut encoded).unwrap();
+        stream.feed_initial_read_data(&encoded).unwrap();
+
+        let err = stream.try_decode_one_frame().unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("session table full"));
+    }
+
+    #[test]
+    fn skips_many_empty_frames_without_recursing() {
+        let mut frames = BytesMut::new();
+        let keepalive = FrameMetadata {
+            session_id: 1,
+            status: SessionStatus::KeepAlive,
+            option: FrameOption::new(),
+            target: None,
+            network: None,
+        };
+        for _ in 0..10_000 {
+            keepalive.encode(&mut frames).unwrap();
+        }
+
+        let target = NetLocation::new(Address::Ipv4(std::net::Ipv4Addr::LOCALHOST), 53);
+        let data_frame = FrameMetadata {
+            session_id: 1,
+            status: SessionStatus::New,
+            option: FrameOption::new().with_data(),
+            target: Some(target.clone()),
+            network: Some(TargetNetwork::Udp),
+        };
+        data_frame.encode(&mut frames).unwrap();
+        frames.put_u16(4);
+        frames.extend_from_slice(b"ping");
+
+        let mut stream = XudpMessageStream::new(Box::new(TestStream));
+        stream.feed_initial_read_data(&frames).unwrap();
+
+        let (data, destination) = stream.try_decode_one_frame().unwrap().unwrap();
+        assert_eq!(data, b"ping");
+        assert_eq!(destination.to_string(), target.to_string());
+    }
+}


### PR DESCRIPTION
## Summary
- Harden protocol parsers and authentication paths across ShadowTLS, Hysteria2, TUIC, VLESS, VMess, XUDP, WebSocket, AnyTLS, REALITY, SOCKS, HTTP, and Shadowsocks.
- Add bounded resource caches/session tables, replay/nonce protections, release-mode bounds checks, and config/debug redaction.
- Bump package version to 0.2.9 and add direct zeroize dependency for REALITY secret cleanup.

## Changes
- Protocol parsing: guard short/truncated frames, padding underflow, VMess AEAD header length, TUIC/Hysteria2 datagrams, VLESS varints, ShadowTLS zero-payload frames, WebSocket control frames.
- Crypto/auth: constant-time comparisons, VMess auth-ID replay cache, VMess nonce exhaustion error, REALITY key zeroization and generic auth failure logs.
- Resource limits: bounded DNS caches, worker queues, AnyTLS streams, TUIC/Hysteria2 UDP sessions, XUDP sessions, and TUIC fragment reassembly.
- Runtime hardening: FFI startup defaults, write_all WriteZero handling, SlideBuffer release asserts, hot-reload error handling, and redacted config Debug output.

## Verification
- cargo fmt --all --check
- git diff --check
- cargo check --locked --lib
- cargo test --locked --lib
- cargo test --locked --bins
- cargo test --locked --release --lib vmess::vmess_stream::tests::test_try_decrypt_rejects_padding_larger_than_data_len
- cargo test --locked --release --lib xudp::message_stream::tests::skips_many_empty_frames_without_recursing
- cargo check --locked --target aarch64-apple-ios --features ffi --lib

## Notes
- Existing warnings remain for unused interface variables in socket_util.rs and Rust 2024 unsafe-op warnings in ffi/ios.rs; they do not fail the checked builds.
- This PR branch also includes the existing local SS2022 clock-skew commit already ahead of upstream.