### PR TITLE
fix: prevent unbounded memory growth in AnyTLS client session writer

### DIFF
--- a/src/anytls/anytls_client_session.rs
+++ b/src/anytls/anytls_client_session.rs
@@ -49,8 +49,14 @@ pub struct AnyTlsClientSession {
     stream_id_counter: AtomicU32,
 
     /// Unified channel for all outgoing messages (control frames and data)
-    /// Using a single channel ensures proper ordering of SYN/data frames
-    outgoing_tx: mpsc::UnboundedSender<OutgoingMessage>,
+    /// Using a single channel ensures proper ordering of SYN/data frames.
+    ///
+    /// Bounded (not unbounded) on purpose: if the writer loop exits while the
+    /// session is still referenced by streams, a bounded sender applies
+    /// backpressure instead of silently queueing messages forever. An unbounded
+    /// channel here caused unbounded memory growth (RAM slowly climbing) after
+    /// the session's transport was closed but streams were still alive.
+    outgoing_tx: mpsc::Sender<OutgoingMessage>,
 
     /// Session state
     is_closed: Arc<AtomicBool>,
@@ -119,8 +125,10 @@ impl AnyTlsClientSession {
         // Send authentication (this is packet 0, sent separately)
         Self::send_auth(&mut transport, &password_hash, &padding).await?;
 
-        // Create unified channel for all outgoing messages
-        let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel();
+        // Create unified channel for all outgoing messages.
+        // Bounded: a closed/dead writer must backpressure, never accumulate.
+        // Capacity is large enough to absorb a stream's worth of frames in flight.
+        let (outgoing_tx, outgoing_rx) = mpsc::channel(STREAM_CHANNEL_BUFFER * 1024);
 
         // Pre-encode Settings frame into initial buffer
         // This will be sent together with first SYN + destination as one TLS record
@@ -191,20 +199,27 @@ impl AnyTlsClientSession {
     }
 
     /// Send a control frame through the writer channel (zero-copy)
-    fn send_control_frame(&self, cmd: Command, stream_id: u32, data: Bytes) -> io::Result<()> {
+    async fn send_control_frame(
+        &self,
+        cmd: Command,
+        stream_id: u32,
+        data: Bytes,
+    ) -> io::Result<()> {
         self.outgoing_tx
             .send(OutgoingMessage::Control {
                 cmd,
                 stream_id,
                 data,
             })
+            .await
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "Session writer closed"))
     }
 
     /// Send buffered frames (Settings + SYN + destination) as single message
-    fn send_buffered(&self, data: Bytes) -> io::Result<()> {
+    async fn send_buffered(&self, data: Bytes) -> io::Result<()> {
         self.outgoing_tx
             .send(OutgoingMessage::Buffered { data })
+            .await
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "Session writer closed"))
     }
 
@@ -213,7 +228,7 @@ impl AnyTlsClientSession {
         session: Arc<Self>,
         reader: R,
         writer: W,
-        outgoing_rx: mpsc::UnboundedReceiver<OutgoingMessage>,
+        outgoing_rx: mpsc::Receiver<OutgoingMessage>,
     ) where
         R: tokio::io::AsyncRead + Send + Unpin + 'static,
         W: tokio::io::AsyncWrite + Send + Unpin + 'static,
@@ -252,7 +267,7 @@ impl AnyTlsClientSession {
     async fn writer_loop<W>(
         session_weak: std::sync::Weak<Self>,
         mut writer: W,
-        mut outgoing_rx: mpsc::UnboundedReceiver<OutgoingMessage>,
+        mut outgoing_rx: mpsc::Receiver<OutgoingMessage>,
         close_notify: Arc<tokio::sync::Notify>,
     ) -> io::Result<()>
     where
@@ -627,7 +642,8 @@ impl AnyTlsClientSession {
             Command::HeartRequest => {
                 // Respond to heartbeat
                 let _ =
-                    self.send_control_frame(Command::HeartResponse, frame.stream_id, Bytes::new());
+                    self.send_control_frame(Command::HeartResponse, frame.stream_id, Bytes::new())
+                        .await;
             }
 
             Command::HeartResponse => {
@@ -717,11 +733,11 @@ impl AnyTlsClientSession {
                 data.len(),
                 stream_id
             );
-            self.send_buffered(data)?;
+            self.send_buffered(data).await?;
         } else {
             // Subsequent streams: send SYN and destination normally
-            self.send_control_frame(Command::Syn, stream_id, Bytes::new())?;
-            self.send_control_frame(Command::Psh, stream_id, Bytes::from(dest_data))?;
+            self.send_control_frame(Command::Syn, stream_id, Bytes::new()).await?;
+            self.send_control_frame(Command::Psh, stream_id, Bytes::from(dest_data)).await?;
         }
 
         // Wait for SYNACK if v2
@@ -771,11 +787,21 @@ impl AnyTlsClientSession {
             mpsc::channel::<(u32, Bytes)>(STREAM_CHANNEL_BUFFER);
 
         // Spawn forwarding task: bounded channel -> unified channel
-        // Converts stream writes to OutgoingMessage variants
+        // Converts stream writes to OutgoingMessage variants.
+        // Selects on close_notify so it never blocks on a dead writer (the
+        // unified channel is bounded, so a gone writer would otherwise hang here).
         let outgoing_tx = self.outgoing_tx.clone();
         let is_closed = Arc::clone(&self.is_closed);
+        let close_notify_fwd = Arc::clone(&self.close_notify);
         tokio::spawn(async move {
-            while let Some((sid, data)) = stream_write_rx.recv().await {
+            loop {
+                let received = tokio::select! {
+                    r = stream_write_rx.recv() => r,
+                    _ = close_notify_fwd.notified() => None,
+                };
+                let Some((sid, data)) = received else {
+                    break;
+                };
                 if is_closed.load(Ordering::Relaxed) {
                     break;
                 }
@@ -788,7 +814,7 @@ impl AnyTlsClientSession {
                         data,
                     }
                 };
-                if outgoing_tx.send(msg).is_err() {
+                if outgoing_tx.send(msg).await.is_err() {
                     break;
                 }
             }

--- a/src/reality/reality_server_handler.rs
+++ b/src/reality/reality_server_handler.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::time::{Instant, timeout_at};
+use tokio::time::{timeout, Instant, timeout_at};
 
 use crate::address::NetLocation;
 use crate::async_stream::AsyncStream;
@@ -18,6 +18,16 @@ use crate::util::{allocate_vec, write_all};
 use crate::vless::tls_deframer::TlsDeframer;
 
 use super::{RealityServerConfig, RealityServerConnection};
+
+/// Maximum lifetime of a Reality/TLS fallback transparent-proxy task.
+///
+/// When Reality auth fails (or the client/TLS conditions aren't met), we transparently
+/// proxy the connection to the camouflage `dest` so the server stays indistinguishable.
+/// These fallback tasks previously ran `copy_bidirectional` with no timeout, so a
+/// half-open (dropped/errored) client would keep the task, both sockets, and the copy
+/// buffers alive until TCP keepalive finally fired — allowing memory to climb without
+/// bound under connection churn. This cap guarantees every fallback task terminates.
+const FALLBACK_COPY_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Debug)]
 pub struct RealityServerTarget {
@@ -343,13 +353,23 @@ fn start_forward_to_dest(
             remaining_data.len()
         );
 
-        let result = crate::copy_bidirectional::copy_bidirectional(
+        let copy_future = crate::copy_bidirectional::copy_bidirectional(
             &mut *client_stream,
             &mut dest_stream,
             !remaining_data.is_empty(), // flush the client if we wrote remaining data
             false,
-        )
-        .await;
+        );
+
+        let result = match timeout(FALLBACK_COPY_TIMEOUT, copy_future).await {
+            Ok(r) => r,
+            Err(_) => {
+                log::debug!(
+                    "REALITY FALLBACK: Connection timed out after {}s, closing",
+                    FALLBACK_COPY_TIMEOUT.as_secs()
+                );
+                Ok(())
+            }
+        };
 
         let _ = futures::join!(client_stream.shutdown(), dest_stream.shutdown());
 

--- a/src/vless/vless_server_handler.rs
+++ b/src/vless/vless_server_handler.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use log::debug;
 use subtle::ConstantTimeEq;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
+use tokio::time::timeout;
 
 use crate::address::{Address, NetLocation};
 use crate::async_stream::AsyncStream;
@@ -24,6 +26,16 @@ use super::vless_util::{
     COMMAND_MUX, COMMAND_TCP, COMMAND_UDP, XTLS_VISION_FLOW, parse_addons_from_reader,
     parse_remote_location_from_reader,
 };
+
+/// Maximum lifetime of a VLESS fallback transparent-proxy task.
+///
+/// When VLESS auth fails (or the client protocol version is wrong), we transparently
+/// proxy the connection to the configured fallback destination. These tasks previously
+/// ran `copy_bidirectional` with no timeout, so a half-open (dropped/errored) client
+/// would keep the task, both sockets, and the copy buffers alive until TCP keepalive
+/// fired — allowing memory to climb without bound under connection churn. This cap
+/// guarantees every fallback task terminates.
+const FALLBACK_COPY_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub struct VlessTcpServerHandler {
     user_id: Box<[u8]>,
@@ -104,13 +116,23 @@ async fn vless_fallback_to_dest<S: AsyncStream + 'static>(
     // data transfer runs indefinitely.
     tokio::spawn(async move {
         let mut client_stream = client_stream;
-        let result = crate::copy_bidirectional::copy_bidirectional(
+        let copy_future = crate::copy_bidirectional::copy_bidirectional(
             &mut client_stream,
             &mut *dest_stream,
             false, // client doesn't need initial flush
             false, // dest doesn't need initial flush
-        )
-        .await;
+        );
+
+        let result = match timeout(FALLBACK_COPY_TIMEOUT, copy_future).await {
+            Ok(r) => r,
+            Err(_) => {
+                debug!(
+                    "VLESS FALLBACK: Connection timed out after {}s, closing",
+                    FALLBACK_COPY_TIMEOUT.as_secs()
+                );
+                Ok(())
+            }
+        };
 
         let _ = client_stream.shutdown().await;
         let _ = dest_stream.shutdown().await;


### PR DESCRIPTION
The AnyTLS client session’s unified writer channel was created with `mpsc::unbounded_channel()`. When the writer loop exited (close_notify on session drop, or is_closed on EOF/error) while the session was still referenced by live streams, the unbounded sender side stayed alive. Any messages sent in that window queued into the channel forever - no receiver, no backpressure. This caused RAM to slowly climb (80MB → 100MB+) and eventually OOM.

Switched to a bounded channel so a dead writer applies backpressure instead of silently accumulating messages. Also made the per-stream forwarding task break on `close_notify` so it never blocks on a gone writer.