### PR TITLE
Parse bracketed IPv6 authorities

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -12,6 +12,30 @@ impl Address {
     pub const UNSPECIFIED: Self = Address::Ipv4(Ipv4Addr::UNSPECIFIED);
 
     pub fn from(s: &str) -> std::io::Result<Self> {
+        // RFC 3986 wraps an IPv6 literal in brackets so that its colons cannot
+        // be mistaken for the port separator, and that is the form clients and
+        // configs actually use: `[::1]:443`. Without this the leading '[' falls
+        // through to the hostname branch below, and the address is handed to
+        // the resolver as a name no DNS server will ever know.
+        //
+        // Brackets mean an IP literal and nothing else - a hostname cannot
+        // contain them - so a bracketed string that is not an IPv6 address is
+        // an error rather than something to look up.
+        if let Some(inner) = s.strip_prefix('[') {
+            let inner = inner.strip_suffix(']').ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Address starts with '[' but has no closing ']': {s}"),
+                )
+            })?;
+            return inner.parse::<Ipv6Addr>().map(Address::Ipv6).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to parse bracketed address as IPv6: {s}: {e}"),
+                )
+            });
+        }
+
         let mut dots = 0;
         let mut possible_ipv4 = true;
         let mut possible_ipv6 = true;
@@ -646,6 +670,97 @@ impl serde::ser::Serialize for NetLocationMask {
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
+
+    /// The bracketed form is how RFC 3986 writes an IPv6 literal, and it is
+    /// what both configs and HTTP clients use. Parsing it as a hostname sends
+    /// it to the resolver, which fails with "Name or service not known" and
+    /// makes an IPv6 server unreachable for a reason the message does not
+    /// explain.
+    #[test]
+    fn test_bracketed_ipv6_is_an_address_not_a_hostname() {
+        for (input, expected) in [
+            ("[::1]", Ipv6Addr::LOCALHOST),
+            ("[2001:db8::1]", "2001:db8::1".parse().unwrap()),
+            // A full eight-group address, with no "::" to shorten it.
+            (
+                "[2001:db8:1:2:3:4:5:6]",
+                "2001:db8:1:2:3:4:5:6".parse().unwrap(),
+            ),
+            ("[::ffff:1.2.3.4]", "::ffff:1.2.3.4".parse().unwrap()),
+        ] {
+            assert_eq!(
+                Address::from(input).unwrap(),
+                Address::Ipv6(expected),
+                "{input} must parse as an address"
+            );
+        }
+    }
+
+    /// Brackets denote an IP literal and nothing else, so a bracketed string
+    /// that is not one must not quietly become a hostname to look up.
+    #[test]
+    fn test_a_bracketed_non_address_is_refused() {
+        for input in [
+            "[]",
+            "[example.com]",
+            "[1.2.3.4]",
+            "[::1",
+            "[not an address]",
+        ] {
+            assert!(
+                Address::from(input).is_err(),
+                "{input} must not parse as an address"
+            );
+        }
+    }
+
+    /// The unbracketed forms have to keep working exactly as before.
+    #[test]
+    fn test_unbracketed_addresses_are_unchanged() {
+        assert_eq!(
+            Address::from("::1").unwrap(),
+            Address::Ipv6(Ipv6Addr::LOCALHOST)
+        );
+        assert_eq!(
+            Address::from("1.2.3.4").unwrap(),
+            Address::Ipv4(Ipv4Addr::new(1, 2, 3, 4))
+        );
+        assert_eq!(
+            Address::from("example.com").unwrap(),
+            Address::Hostname("example.com".to_string())
+        );
+    }
+
+    /// The whole point of the brackets: the colons inside them are part of the
+    /// address, and the one after them separates the port.
+    #[test]
+    fn test_a_bracketed_location_separates_the_port() {
+        let location = NetLocation::from_str("[2001:db8::1]:2096", None).unwrap();
+        assert_eq!(
+            location.address(),
+            &Address::Ipv6("2001:db8::1".parse().unwrap())
+        );
+        assert_eq!(location.port(), 2096);
+
+        // And without a port, the default applies.
+        let location = NetLocation::from_str("[2001:db8::1]", Some(443)).unwrap();
+        assert_eq!(
+            location.address(),
+            &Address::Ipv6("2001:db8::1".parse().unwrap())
+        );
+        assert_eq!(location.port(), 443);
+
+        // A bracketed address with no port and no default is still an error.
+        assert!(NetLocation::from_str("[2001:db8::1]", None).is_err());
+    }
+
+    /// Port ranges take the same notation.
+    #[test]
+    fn test_a_bracketed_port_range_parses() {
+        let range = NetLocationPortRange::from_str("[2001:db8::1]:80,443").unwrap();
+        assert_eq!(range.address, Address::Ipv6("2001:db8::1".parse().unwrap()));
+        assert_eq!(range.ports, vec![80, 443]);
+    }
 
     #[test]
     fn test_netlocation_serialization() {

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -98,24 +98,16 @@ pub async fn setup_http_server_stream_inner(
         if line.starts_with("CONNECT ") {
             let address = &line[8..line.len() - 9];
 
-            let separator_index = address.find(':').ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid address format")
-            })?;
-
-            if address.len() <= separator_index + 1 {
-                return Err(std::io::Error::new(
+            // Splitting on the first ':' breaks the bracketed IPv6 authority
+            // an HTTP client sends for an IPv6 destination, `[::1]:443`: the
+            // first colon is inside the address. NetLocation handles the
+            // brackets, and CONNECT has no default port, so None.
+            let remote_location = NetLocation::from_str(address, None).map_err(|e| {
+                std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "Invalid address format",
-                ));
-            }
-
-            let domain_name = &address[0..separator_index];
-
-            let port = address[separator_index + 1..]
-                .parse::<u16>()
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-
-            let remote_location = NetLocation::new(Address::from(domain_name)?, port);
+                    format!("Invalid CONNECT address '{address}': {e}"),
+                )
+            })?;
 
             // wait for an empty \r\n before connecting, and check for auth header line if needed.
             let mut need_auth = auth_token.is_some();
@@ -204,15 +196,14 @@ pub async fn setup_http_server_stream_inner(
                 None => (url, "/"),
             };
 
-            let remote_location = match address.find(':') {
-                Some(i) => {
-                    let port = address[i + 1..]
-                        .parse::<u16>()
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-                    NetLocation::new(Address::from(&address[0..i])?, port)
-                }
-                None => NetLocation::new(Address::from(address)?, 80),
-            };
+            // Same as CONNECT above, except that an absolute http:// URL may
+            // leave the port out, in which case it is 80.
+            let remote_location = NetLocation::from_str(address, Some(80)).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Invalid forward url authority '{address}': {e}"),
+                )
+            })?;
 
             let mut request = format!("{directive} {location} {http_version}\r\n");
 
@@ -447,5 +438,124 @@ impl TcpClientHandler for HttpTcpClientHandler {
             client_stream,
             early_data,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::{TcpListener, TcpStream};
+
+    use crate::client_proxy_selector::{ConnectAction, ConnectRule};
+    use crate::resolver::NativeResolver;
+
+    /// A selector that allows everything, so the test observes the parsed
+    /// destination rather than a routing decision.
+    fn allow_all() -> Arc<ClientProxySelector> {
+        let resolver: Arc<dyn Resolver> = Arc::new(NativeResolver::new());
+        let chain_group = crate::tcp::chain_builder::build_client_chain_group(
+            crate::option_util::NoneOrSome::None,
+            resolver,
+        );
+        Arc::new(ClientProxySelector::new(vec![ConnectRule::new(
+            vec![crate::address::NetLocationMask::ANY],
+            ConnectAction::new_allow(None, chain_group),
+        )]))
+    }
+
+    /// Feed one request to the handler and return where it decided to connect.
+    ///
+    /// The handler returns before dialling, so nothing here touches the
+    /// network beyond the loopback pair carrying the request.
+    async fn destination_of(request: &str) -> std::io::Result<NetLocation> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let request = request.to_string();
+        let client = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream.write_all(request.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            // Hold the connection open until the handler is done with it.
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        });
+
+        let (server, _) = listener.accept().await.unwrap();
+        let result = setup_http_server_stream_inner(
+            None,
+            Box::new(server),
+            StreamReader::new(),
+            allow_all(),
+        )
+        .await;
+        client.abort();
+
+        match result? {
+            TcpServerSetupResult::TcpForward {
+                remote_location, ..
+            } => Ok(remote_location),
+            _ => panic!("expected a TCP forward"),
+        }
+    }
+
+    /// An HTTP client asking for an IPv6 destination sends the address in
+    /// brackets, exactly so the colons cannot be read as the port separator.
+    /// Splitting on the first ':' takes one from inside the address and the
+    /// request is refused, which makes every IPv6 literal unreachable through
+    /// the HTTP inbound.
+    #[tokio::test]
+    async fn test_connect_accepts_a_bracketed_ipv6_authority() {
+        let destination = destination_of("CONNECT [2001:db8::1]:443 HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        assert_eq!(
+            destination,
+            NetLocation::new(Address::Ipv6("2001:db8::1".parse().unwrap()), 443)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connect_still_takes_a_hostname_and_port() {
+        let destination = destination_of("CONNECT example.com:8443 HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        assert_eq!(
+            destination,
+            NetLocation::new(Address::Hostname("example.com".to_string()), 8443)
+        );
+    }
+
+    /// CONNECT has no default port, so an authority without one is a bad
+    /// request rather than a guess.
+    #[tokio::test]
+    async fn test_connect_without_a_port_is_refused() {
+        assert!(
+            destination_of("CONNECT example.com HTTP/1.1\r\n\r\n")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_forward_url_accepts_a_bracketed_ipv6_authority() {
+        let destination = destination_of("GET http://[2001:db8::1]:8080/path HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        assert_eq!(
+            destination,
+            NetLocation::new(Address::Ipv6("2001:db8::1".parse().unwrap()), 8080)
+        );
+    }
+
+    /// An absolute URL may leave the port out, and then it is 80.
+    #[tokio::test]
+    async fn test_a_forward_url_without_a_port_defaults_to_80() {
+        let destination = destination_of("GET http://example.com/path HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        assert_eq!(
+            destination,
+            NetLocation::new(Address::Hostname("example.com".to_string()), 80)
+        );
     }
 }


### PR DESCRIPTION
## Problem

A bracketed IPv6 authority is parsed as a hostname. On master:

```rust
NetLocation::from_str("[2001:db8::1]:443", None)
// => Ok((Hostname("[2001:db8::1]"), 443))
```

`Address::from` classifies by scanning bytes, and a leading `[` is neither a
digit, a hex letter, `:` nor `.`, so it clears the IPv4 and IPv6 flags and the
string falls through to the hostname branch. It then goes to the resolver,
which answers "Name or service not known". `[host]:port` is the form RFC 3986
defines and the form HTTP clients send, so an IPv6 outbound written the normal
way is unreachable, and the error says nothing about why.

The HTTP inbound has the same problem for a different reason: it splits the
CONNECT authority on the first `:`, which for an IPv6 literal sits inside the
address. `CONNECT [2001:db8::1]:443` is refused, and so is a forward URL like
`GET http://[2001:db8::1]/`.

## Fix

`address: parse the bracketed IPv6 form` strips the brackets in `Address::from`
and parses the interior as an `Ipv6Addr`. Brackets mean an IP literal and
nothing else, so a bracketed string that is not an IPv6 address is now an error
rather than a name to look up: `[example.com]`, `[1.2.3.4]` and an unterminated
`[::1` are all refused. `NetLocation::from_str` needed no change, since its
`rfind(':')` already lands on the port separator once the address itself parses.

`http: accept a bracketed IPv6 authority` parses the CONNECT target and the
forward-URL authority through `NetLocation` instead of splitting on the first
colon.

## Tests

Five in `address.rs`: the bracketed form (compressed, full eight-group and
IPv4-mapped), the refusals above, a bracketed authority with a port, a
bracketed port range, and unbracketed addresses still parsing as they did. Two
in `http_handler.rs` drive a request through the handler, one for CONNECT and
one for a forward URL.

`cargo test` passes (783), `cargo fmt --check` is clean, and `cargo clippy`
reports nothing new.
